### PR TITLE
Fall 2026 roster and recruitment timeline

### DIFF
--- a/src/apply/apply.js
+++ b/src/apply/apply.js
@@ -54,7 +54,7 @@ const Apply = () => {
                <div className="left">
                    <h3>APPLY</h3>
                    <h1>Join our Family</h1>
-                   <p>Our application for Spring 2026 is now closed. Stay tuned for more information about our next application cycle!</p>
+                   <p>Stay tuned for information about our upcoming Fall 2026 recruitment cycle!</p>
                    {/*<Button
                        link={interestForm}
                        buttonText="Interest Form"
@@ -92,9 +92,9 @@ const Apply = () => {
                    <div className="item">
                        <img src={chat} alt="chat icon" />
                        <h4>Tabling</h4>
-                       <p>Tuesday, 1/20 – Thursday, 1/29</p>
+                       <p>Wednesday, 8/26 – Friday, 9/4</p>
                        <ul>
-                           <li>From January 20th through January 29th between 8AM - 4PM, come say hi on at our table on Sproul!</li>
+                           <li>From August 26th through September 4th between 8AM - 4PM, come say hi on at our table on Sproul!</li>
                            {/* <li>Sign up for a 1:1 with a NIB member sometime January 17th - 26th.</li> */}
                            <li>Fill out our <a className="underline-magical" href={interestForm} target="_blank" rel="noopener noreferrer">interest form</a>!</li>
                        </ul>
@@ -102,7 +102,7 @@ const Apply = () => {
                    <div className="item">
                        <img src={network} alt="chat icon" />
                        <h4>Infosessions</h4>
-                       <p>Tuesday, 1/27 - Thursday, 1/29</p>
+                       <p>Tuesday, 9/1 - Thursday, 9/3</p>
                        <ul>
                            <li>Tuesday: Infosession #1</li>
                            <li>Wednesday: Infosession #2 + Case Demonstration</li>
@@ -112,9 +112,9 @@ const Apply = () => {
                    <div className="item">
                        <img src={doc} alt="chat icon" />
                        <h4>Applications and Interviews</h4>
-                       <p>Friday 1/30 - Tuesday 2/3</p>
+                       <p>Friday 9/4 - Wednesday 9/9</p>
                        <ul>
-                           <li>Applications are due at 1PM PST on January 30th.</li>
+                           <li>Applications are due at 1PM PST on September 4th.</li>
                            {/* Apply <a className="underline-magical" href={application} target="_blank" rel="noopener noreferrer"> here. </a> */}
                            <li>Check out our interview FAQ and tips <a className="underline-magical" href="/nib-app-checklist.pdf" target="_blank" rel="noopener noreferrer"> here! </a></li>
                        </ul>

--- a/src/apply/apply.js
+++ b/src/apply/apply.js
@@ -24,7 +24,7 @@ import {ReactComponent as DownArrow} from './img/atAGlance/down.svg';
 const Apply = () => {
    const virtualTablingLink = "https://berkeley.zoom.us/j/95663292195";
    const coffeeChatSignUp = "https://airtable.com/shr5tNafnTL2VsY33";
-   const interestForm = "https://airtable.com/appzavtFjBRUlUmPt/pagqItCKlhH3VB25J/form";
+   const interestForm = "https://airtable.com/app6CUasmCcQ4YrJd/pagqItCKlhH3VB25J/form";
    const application = "https://airtable.com/appk87G4bajdKguxx/pagasA5eZl1Uy0Ca9/form";
    const caseCoachingSignUp = "https://berkeley.zoom.us/meeting/register/tJEkdu-urjspGtA68NPJLepuKa-CBfMsTvm3";
    const infosession1 = "https://berkeley.zoom.us/j/99404517995?pwd=Q1ljRTlwb3RBdG9TUFpUTzY0L0UvUT09";

--- a/src/apply/data/timeline.js
+++ b/src/apply/data/timeline.js
@@ -7,7 +7,7 @@ let Timeline = [{
     date: "August 26th - September 4th, 8am - 4pm PST | Sproul/Glade",
     title: "Tabling",
     description: "Drop by Sproul and Memorial Glade to learn more about our people, projects, and impact! Take this time to meet our incredible members and to ask any questions about consulting for Net Impact.",
-    link: "https://airtable.com/appzavtFjBRUlUmPt/pagqItCKlhH3VB25J/form",
+    link: "https://airtable.com/app6CUasmCcQ4YrJd/pagqItCKlhH3VB25J/form",
     linkText: "Interest Form",
 },
 {
@@ -18,17 +18,17 @@ let Timeline = [{
     linkText: "Meet our Members",
 },
 {
-    date: "Tuesday, September 1st, 8-10 PM PST | VLSB 2040",
+    date: "Tuesday, September 1st, 8-10 PM PST | Location TBD",
     title: "Info Session #1",
     description: "Join us at one of our info sessions to get a glimpse into what it means to be part of Net Impact Berkeley and to see what we offer to all majors, backgrounds, and interests. You'll have the opportunity to learn more about our upcoming projects, socials, trainings and external events and to connect with all of our members.",
 },
 {
-    date: "Wednesday, September 2nd, 8-10 PM PST | VLSB 2040",
+    date: "Wednesday, September 2nd, 8-10 PM PST | Location TBD",
     title: "Info Session #2 + Case Workshop",
-    description: "We will hold an open networking session from 8-9pm outside of VLSB to provide an opportunity to meet our members and learn about their past experiences as members of NIB. From 9-10pm we host a case workshop to help walk you through the case portion of our interview and what to expect from the overall interview process. This includes best practices, a sample case, and time to ask questions.",
+    description: "We will hold an open networking session from 8-9pm to provide an opportunity to meet our members and learn about their past experiences as members of NIB. From 9-10pm we host a case workshop to help walk you through the case portion of our interview and what to expect from the overall interview process. This includes best practices, a sample case, and time to ask questions.",
 },
 {
-    date: "Thursday, September 3rd, 8-10 PM PST | VLSB 2040",
+    date: "Thursday, September 3rd, 8-10 PM PST | Location TBD",
     title: "Case Coaching Session",
     description: "Come learn about Net Impact's interview process and how to crush a case interview at our Case Coaching Session. You'll have the chance to work in small groups to solve a real world case and learn how to approach and solve case interview questions.",
 },

--- a/src/apply/data/timeline.js
+++ b/src/apply/data/timeline.js
@@ -4,63 +4,63 @@
 // import youtube from '../img/youtube.png';
 
 let Timeline = [{
-    date: "January 20th - January 29th, 8am - 4pm PST | Sproul/Glade",
+    date: "August 26th - September 4th, 8am - 4pm PST | Sproul/Glade",
     title: "Tabling",
     description: "Drop by Sproul and Memorial Glade to learn more about our people, projects, and impact! Take this time to meet our incredible members and to ask any questions about consulting for Net Impact.",
     link: "https://airtable.com/appzavtFjBRUlUmPt/pagqItCKlhH3VB25J/form",
     linkText: "Interest Form",
 },
 {
-    date: "January 20th - January 29th, 8am - 6pm PST | Zoom/In Person",
+    date: "August 26th - September 4th, 8am - 6pm PST | Zoom/In Person",
     title: "Coffee Chats",
     description: "Sign up for a 20 minute chat with one of our members anytime to meet someone from our community.",
     link: "https://nib.berkeley.edu/members",
     linkText: "Meet our Members",
 },
 {
-    date: "Tuesday, January 27th, 8-10 PM PST | VLSB 2040",
+    date: "Tuesday, September 1st, 8-10 PM PST | VLSB 2040",
     title: "Info Session #1",
     description: "Join us at one of our info sessions to get a glimpse into what it means to be part of Net Impact Berkeley and to see what we offer to all majors, backgrounds, and interests. You'll have the opportunity to learn more about our upcoming projects, socials, trainings and external events and to connect with all of our members.",
 },
 {
-    date: "Wednesday, January 28th, 8-10 PM PST | VLSB 2040",
+    date: "Wednesday, September 2nd, 8-10 PM PST | VLSB 2040",
     title: "Info Session #2 + Case Workshop",
     description: "We will hold an open networking session from 8-9pm outside of VLSB to provide an opportunity to meet our members and learn about their past experiences as members of NIB. From 9-10pm we host a case workshop to help walk you through the case portion of our interview and what to expect from the overall interview process. This includes best practices, a sample case, and time to ask questions.",
 },
 {
-    date: "Thursday, January 29th, 8-10 PM PST | VLSB 2040",
+    date: "Thursday, September 3rd, 8-10 PM PST | VLSB 2040",
     title: "Case Coaching Session",
     description: "Come learn about Net Impact's interview process and how to crush a case interview at our Case Coaching Session. You'll have the chance to work in small groups to solve a real world case and learn how to approach and solve case interview questions.",
 },
 {
-    date: "Friday, January 30th, 1 PM PST",
+    date: "Friday, September 4th, 1 PM PST",
     title: "Applications Due",
     description: "Our application consists of a resume drop and a few short answer questions. Please submit your application by 1 PM on Friday if you'd like to apply!",
     // link: "https://airtable.com/app5kIIT8OgWGBQWj/pagO6AnGJoBTImhIN/form",
     //linkText: "Application"
 },
 {
-    date: "Saturday, January 31st",
+    date: "Saturday, September 5th",
     title: "First Round Interviews",
     description: "Invite Only",
 },
 {
-    date: "Sunday, February 1st",
+    date: "Sunday, September 6th",
     title: "Meet Net Impact Berkeley",
     description: "Invite Only",
 },
 {
-    date: "Monday, February 2nd",
+    date: "Monday, September 7th",
     title: "Coffee Chats",
     description: "Invite Only",
 },
 {
-    date: "Tuesday, February 3rd",
+    date: "Tuesday, September 8th",
     title: "Second Round Interviews",
     description: "Invite Only",
 },
 {
-    date: "Thursday, February 5th",
+    date: "Wednesday, September 9th",
     title: "Welcome to Net Impact Berkeley",
     description: "Invite Only",
 }

--- a/src/members/data/memberInfo.js
+++ b/src/members/data/memberInfo.js
@@ -1,35 +1,8 @@
 let memberInfo = {
     execList: [
         {
-            name: 'Muhammed Ibrahim Bakr', 
-            title: 'President',
-            bio: [
-                "Hey I'm Muhammed, a senior born and raised in Botswana, majoring in Economics, and minoring in Global Poverty Practice and Data Science. I joined NIB in Fall '23 and it's been one of my best decisions in college. Not only have I gained invaluable experience at companies I dream of working for, on projects I feel are truly meaningful, I've also made some of my closest friends since coming to America.",
-                "I'm super interested in extreme poverty alleviation, and NIB has helped me channel that passion through our work with the World Bank on WASH in the Pacific, and the Global Alliance for Improved Nutrition (GAIN) on food security in East Africa. I've also worked on econometric analysis on California wildfire resilience projects for the EDF and sales strategy for Climeworks, a leader in the direct air capture premium carbon offset credit market.",
-                "Talk to me about anything football/soccer related (I'm a Liverpool fan), the NBA (Golden State), Effective Altruism, or music (Afro beats, Dominic Fike, J. Cole, JID, Mac Miller)."
-            ],
-            linkedin: 'https://www.linkedin.com/in/muhammed-bakr/',
-            calendly: 'https://calendly.com/muhammed-bakr/nib-coffee-chats',
-            image: require('../img/prof/muha.jpg'),
-            sillyImage: require('../img/funny/muha.png'),
-            isDM: true
-        },
-        {
-            name: 'Ashni Sheth', 
-            title: 'VP Finance & Operations',
-            bio: [
-                "Hi hi! I'm Ashni - I'm a fourth year studying EECS and joined NIB in my sophomore spring. Since then, I've had the immense privilege of calling this community home, building the deepest friendships and support system I could have asked for. During my time at NIB, I've worked on market expansion for The Hunger Project and marketing strategy for the United Nations Foundation.",
-                "Outside of NIB, I have trained in dance for over 15 years and am part of a team at Berkeley (shoutout Zahanat)! I'm also a member of Alpha Delta Pi (ADPi) and deeply involved in venture capital and entrepreneurship on- and off-campus. I am thrilled to have the opportunity to meet you!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/ashni-sheth-4629041b3/',
-            calendly: 'https://calendly.com/ashni_sheth/nib-coffee-chats',
-          image: require('../img/prof/ashni.jpg'),
-            sillyImage: require('../img/funny/ashni.png'),
-            isDM: true
-        },
-        {
             name: 'Ice Kulruchakorn', 
-            title: 'VP Associate Development',
+            title: 'President',
             bio: [
                 "Hey there! My name is Ice, and I'm a junior studying Political Science and Data Science. I was born in Thailand but went to high school in Singapore, but despite third culture kid struggles, I felt right at home with NIB since I joined in my freshman fall semester. I've worked with a microfinance nonprofit, an EdTech company, and an international organization with problems ranging from go-to-market strategy to reinvesting strategic narratives for fundraising. One of the things I love most about NIB is how this club never fails to inspire and motivate me to become a better person.",
                 "I'm passionate about increasing the quality of and access to education, and the democratization efforts in the Global South. I'm also an aspiring UI/UX designer (waiting for NIB to officially appoint me as the resident figma girl), and I enjoy various forms of writing and performance arts! Here are some of my favorite writers and works: Laufey, Rex Orange County, Daniel Caesar, Ocean Vuong, F. Scott Fitzgerald, Eriks Esenvalds, La La Land, Everything Everywhere All at Once, Hadestown."
@@ -41,60 +14,21 @@ let memberInfo = {
             isDM: true
         },
         {
-            name: 'Diane Shih', 
-            title: 'VP Consulting',
+            name: 'Aswin Surya', 
+            title: 'VP Finance & Operations',
             bio: [
-                "Hi! I'm Diane, and I'm a third year studying Business, Cognitive Science, and Data Science. I joined NIB during my freshman spring semester and have truly loved every second! NIB is such an amazing and supportive community, and I've felt so very lucky to be a part of it. During my time with NIB, I've worked with a global edTech company on AI strategy, the World Bank on WASH financing, and the Environmental Defense Fund on cost-benefit analysis of wildfire treatments (super cool and awesome stuff!!).",
-                "I'm very passionate about neurodiversity, education, and environmental sustainability, and NIB has helped me further these passions through the unique, genuine, and impactful work that we do. Feel free to reach out if you want to talk about any and all things music, really terrible puns/dad jokes, travel (yet having no sense of direction), questions about NIB, or really anything you want!",
-            ],
-            linkedin: 'https://www.linkedin.com/in/diane-shih',
-            image: require('../img/prof/diane.jpg'),
-            sillyImage: require('../img/funny/dgshih.png'),
-            isDM: true
-        },
-        {
-            name: 'Tanya Chandok',
-            title: 'VP External',
-            bio: [
-               "Hey! I'm Tanya, a junior majoring in Molecular & Cellular Biology and Economics from Vancouver, Canada. Joining NIB has been an incredible journey and it’s truly my second family on campus, providing me with endless opportunities for growth and some of the most amazing friendships I could ask for. My past projects have included working with a consumer tech-focused venture capital fund to analyze investment opportunities in Latin America's rapidly evolving digital landscape, as well as with a leading geothermal energy company to identify strategic partnerships to expand their global footprint and advancing sustainable energy solutions.",
-                "I am deeply passionate about addressing water accessibility challenges and I have channeled that passion by developing low-cost water purification methods and leading initiatives to educate and empower remote Indigenous communities with sustainable and culturally informed solutions.",
-                "Outside of NIB, tennis has been a central part of my life. I’ve been playing and directing tennis programs for 12 years and it’s shaped so much of who I am! I am involved in tumor immunotherapy research, exploring strategies to combat cancer and improve patient outcomes. I’m also a member of Alpha Delta Pi, where I’ve led Diversity, Equity, and Inclusion initiatives across Greek life, working to foster a more inclusive and welcoming community on campus. In my free time, I love shopping (NIB’s Aritzia plug), pilates (I’m practically my studio’s unofficial ambassador), and cooking (I make a mean Nobu Tuna Crispy Rice dupe).",
-                "Can't wait to meet you and share more about the amazing experiences NIB has to offer!",
-            ],
-            linkedin: 'https://www.linkedin.com/in/tanyachandok/',
-            calendly: 'https://calendly.com/tanyachandok-berkeley/coffee-chats',
-            image: require('../img/prof/tanya.jpg'),
-            sillyImage: require('../img/funny/tanya.png'),
-            isDM: true
-        },
-        {
-            name: 'Maddie Bhuvan', 
-            title: 'VP Internal',
-            bio: [
-                "Hey! I’m Maddie, an intended Business, Psychology, and Cognitive Science major, and this is my third semester in NIB. I am so grateful for the amazing memories I’ve made so far; this club has brought me some of my closest friends!",
-                "I am very passionate about LGBTQ+ inclusivity, educational accessibility, environmental sustainability, and mental health awareness. Outside of NIB, I love to dance, take cool pictures, sing, hike, collect matchboxes, and play the drums. I’m also always on the lookout for good music, thrift stores, food, and boba/matcha (pmo if you have recs please)!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/madhurum-bhuvan',
-            image: require('../img/prof/maddie.jpg'),
-            sillyImage: require('../img/funny/madhurum.png'),
-            isDM: true
-        },
-        {
-            name: 'Renaissance Zhang',
-            title: 'Project Manager',
-            bio: [
-               "Hi!! I'm Renaissance, a junior studying Political Science and Cognitive Science. I joined NIB Fall 2024, and it has easily been the best experience I've had at Cal! NIB is an incredibly supportive, fun, and rewarding- the people are the best part. In the past, I worked on pitching global health funding as a strategic U.S. investment, as well as worked on increasing the prevalence of pro bono lego work with the Pro Bono Institute. Most recently, I worked with Fender on business & product strategy!",
-                "Outside of NIB, I am a human rights activist (anti-genocide, climate crisis, reproductive access), a huge Swiftie, and a debater. I love reading, baking, playing Marvel Rivals, and watching various anime shows. So excited to meet you!!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/renaissancezhang/',
-            calendly: 'https://calendly.com/rzhang0326-berkeley/nib-coffee-chats-sp25-1?month=2025-01',
-            image: require('../img/prof/ren.jpg'),
-            sillyImage: require('../img/funny/ren.png'),
-            isDM: true
+                "Hey! I'm Aswin, a sophomore from the Bay Area studying EECS. I joined NIB freshman fall, and it is honestly the best decision I've made at Berkeley. In the last year, NIB has given me so many opportunities, from a free Michelin dinner to presenting global health strategy to the United Nations in DC to meeting the most amazing community on campus. I'm particularly passionate about healthcare, and the intersection of tech and health, using digital tools to ensure quality and accessible healthcare for all.",
+                "I'm also on leadership in Dil Se, Berkeley's South Asian A Cappella Team and am in Berkeley AI Research, where I work on hybrid systems, LLMs, and cybersecurity.",
+                "Outside of NIB, I love lifting, listening to any and all types of music, and playing basketball and tennis. My goal is to try every single food place at Berkeley, so if you have any unique favorites, don't hesitate to hit me up. Looking forward to chatting with you :)"],
+            linkedin: 'https://www.linkedin.com/in/aswinsurya/',
+            calendly: 'https://calendly.com/aswinsurya/nib-coffee-chats',
+            image: require('../img/prof/Aswin.jpg'),
+            sillyImage: require('../img/funny/aswin.png'),
+            isDM: false
         },
         {
             name: 'Lauren Lemire',
-            title: 'Project Manager',
+            title: 'VP External',
             bio: [        
                 "Hi! I’m Lauren, a junior majoring in Political Economy with a minor in Public Policy. I joined NIB in my sophomore fall, and it’s easily one of the best decisions I’ve made at Cal. Since then, I’ve worked on incredible projects in the healthcare and sustainable development space, while also getting to learn from some of the most inspiring people I’ve ever met. The work has been rewarding, but the community and memories have been even better. #NIBFam!!!",
                 "Outside of NIB, I’m all about sports, the outdoors, and trying new hobbies. I competed for Cal Track & Field as a thrower for two years and now train independently, LA28 perhaps? Until then, you’ll probably catch me at open gym volleyball, listening to music, or learning salsa this year. Can’t wait to meet you!"
@@ -106,21 +40,34 @@ let memberInfo = {
             isDM: true
         },
         {
-            name: 'Javier Gonzales',
-            title: 'Project Manager',
+            name: 'Renaissance Zhang',
+            title: 'VP Internal',
             bio: [
-               "Hi! I'm Javi, currently a Junior studying EECS. I've been in NIB for a couple semesters now and I haven't looked back since! NIB has been an amazing place for me to learn much more outside of my traditional coursework and take on meaningful work that truly does have an impact. I've met so many new and amazing people that truly inspire me everyday.", 
-               "Outside of NIB I love folding clothes, playing soccer, watching gorilla videos, backpacking, and baked goods."
+               "Hi!! I'm Renaissance, a junior studying Political Science and Cognitive Science. I joined NIB Fall 2024, and it has easily been the best experience I've had at Cal! NIB is an incredibly supportive, fun, and rewarding- the people are the best part. In the past, I worked on pitching global health funding as a strategic U.S. investment, as well as worked on increasing the prevalence of pro bono lego work with the Pro Bono Institute. Most recently, I worked with Fender on business & product strategy!",
+                "Outside of NIB, I am a human rights activist (anti-genocide, climate crisis, reproductive access), a huge Swiftie, and a debater. I love reading, baking, playing Marvel Rivals, and watching various anime shows. So excited to meet you!!"
             ],
-            linkedin: 'https://www.linkedin.com/in/javiercgonzales',
-            calendly: 'https://calendly.com/javiergonzales-berkeley/30min',
-            image: require('../img/prof/javi.jpg'),
-            sillyImage: require('../img/funny/javi.png'),
+            linkedin: 'https://www.linkedin.com/in/renaissancezhang/',
+            calendly: 'https://calendly.com/rzhang0326-berkeley/nib-coffee-chats-sp25-1?month=2025-01',
+            image: require('../img/prof/ren.jpg'),
+            sillyImage: require('../img/funny/ren.png'),
             isDM: true
         },
         {
+            name: 'Maitree Meher',
+            title: 'VP Associate Development',
+            bio: [
+                "Hey! I am Maitree & I am a junior studying EECS & Business. This past semester has been my best one at Berkeley, and NIB was the biggest reason why. The community here is incredible, I’ve built some of my closest friendships through it, I have so many wonderful memories with NIB & my fav one has to be wave crashing with my project team (Environmental Defense Fund) in Hawaii. I’m so grateful for everything I’ve experienced with NIB; it’s made my time at Berkeley more meaningful, and so much more fun.",
+                "Outside of NIB, I am interested in research and interned as a Quant Researcher at Squarepoint in London this summer. I am involved in M.E.T., CIB, and recently got into running. Excited to meet you this semester!]"
+            ],
+            linkedin: 'https://www.linkedin.com/in/maitreemeher/',
+            calendly: 'https://calendly.com/maitree-meher-berkeley/nib-calendly',
+            image: require('../img/prof/Maitree.jpg'),
+            sillyImage: require('../img/funny/maitree.png'),
+            isDM: false
+        },
+        {
             name: 'Eshaan Shaik', 
-            title: 'Project Manager',
+            title: 'VP Consulting',
             bio: [
                 "Hey everyone! I’m Eshaan and I’m a sophomore studying Business and Data Science with a minor in Public Policy. I joined NIB my freshman fall and I’ve had the immense pleasure of calling this community home. From the kind, supportive members to the social-impact oriented projects, I can’t imagine my college experience here without NIB.",
                 "Regarding my projects, I worked on strategy for one of the biggest NGOs in the world where we researched grant-funding, explored climate finance, and decked countless number of slides to help international refugees. I also worked on a project which found cost-effective methods for wildfire resilience through data analytics methods and countless hours of research! Besides projects, NIB's focus on social impact has always been what sets us apart and makes the entire experience far more fulfilling!",
@@ -128,58 +75,77 @@ let memberInfo = {
             ],
             linkedin: 'http://www.linkedin.com/in/eshaan-shaik-62433b211',
             calendly: "https://calendly.com/eshaan_shaik-berkeley/nib-coffee-chats",
-            image: require('../img/prof/eshaan.jpg'),
+            image: require('../img/prof/Eshaan.jpg'),
             sillyImage: require('../img/funny/eshaan.png'),
             isDM: true
         },
-    ],
-    pmList: [
-        /* add when we go back to 5 pms lol */
-    ],
-
-    memberList: [
+        {
+            name: 'Harper Young',
+            title: 'Project Manager',
+            bio: [
+              "Hey there!! My name is Harper Young, I am a freshman studying Environmental Economics and Policy and a returning associate this year. I LOVE NIB, and joining was the best thing I've done at college so far. The people here are the kindest and most genuine people I have ever met, while being the most fun and phenomenal to hang out with. I learned so much from my past project with SC Johnson, but more importantly, forged friendships with nib members who inspire and challenge me every day. #NIBISLITNIBISIT #NIBFAM",
+                "I'm passionate about sustainable development, whether that's regenerative agriculture, restorative infrastructure, energy grids, policy, or habitat conservation. I am also interested in youth literacy, especially for marginalized youth, and advancing equal opportunity in our education systems. Outside of NIB, I love to ski, backpack, hike, cook, and go on any adventure possible (bonus points if someone can teach me how to surf). Please talk to me about whatever gets you excited!!!!!"
+               ],
+            linkedin: 'https://www.linkedin.com/in/harper-young-2685b6307/',
+            calendly: 'https://calendly.com/harperyoung-berkeley/30min',
+            image: require('../img/prof/harper.png'),
+            sillyImage: require('../img/funny/harper.png'),
+            isDM: false
+        },
         {
             name: 'Elias Goss',
-            title: 'Senior Associate',
+            title: 'Project Manager',
             bio: [
                "Wassup, I'm Elias, a Sophomore from Denver, Colorado, studying Business Administration and Political Economy. I joined NIB in the second semester of my freshman year, and I will be a returning associate this Fall! My last project involved working with Fervo Energy. My interests include religion, football, basketball, cooking, weightlifting, rock climbing, trading, AI, and public speaking."
                ],
             linkedin: 'https://www.linkedin.com/in/eliasgoss/',
             calendly: 'https://calendly.com/eliasgoss2005-berkeley',
-            image: require('../img/prof/elias.jpg'),
+            image: require('../img/prof/Elias.jpg'),
             sillyImage: require('../img/funny/elias.png'),
             isDM: false
         },
         {
-            name: 'Anika Yu',
-            title: 'Senior Associate',
+            name: 'Luis Suarez',
+            title: 'Project Manager',
             bio: [
-                "Hi, I’m Anika and I’m a sophomore studying Political Economy, Data Science, and Public Policy. I joined NIB my freshman spring (SP25 CLASS ON TOP!) and could not have been more grateful for the memories I've gained, coming up on one year in the club. NIB not only broadened my concept of what my academic and professional career could look like, but also provided me with the most supportive and sweet friends ever. I can never shut my mouth around them, whether it's presenting a deliverable to a nonprofit CEO or making up a derpy language that only my team understands #fendyforever.",
-                "I am super passionate about equitable policymaking and participatory democracy, especially in the field of education. Ultimately, I want to be a public interest lawyer! I'd love to talk about how my previous projects, Pro Bono Institute and Fender, have intersected with these passions. We can also connect over cool books, elite food spots, and recent budding interests (mine are running and F1!)",
-                "There is never a dull moment in NIB and I am so excited for you to discover what that could look like for yourself through recruitment!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/anika-yu/',
-            calendly: 'https://calendly.com/anika-yu/nib-spring-26-coffee-chats-anika',
-            image: require('../img/prof/anika.jpg'),
-            sillyImage: require('../img/funny/anika.png'),
+              "Hello there!!! My name is Luis, and I am a Sophomore studying Business & Compsci!!! I just joined NIB last semester (Spring 2025), and it has been one of the best decisions I have made in college so far. NIB has provided me with a strong professional exposure to the Business world while having a solid social impact foundation. This passion for social impact is visible through the culture in the club, the projects we undertake, and our members' lives outside of NIB. I cannot wait to see how this club continues to grow as we welcome a new class. In just a semester, NIB has become a family to me, and I would love to see that happen in others as well.",
+              "If you have any questions, please do not hesitate to reach out!!! Goodluck :DDDD"],
+            linkedin: 'https://www.linkedin.com/in/luis-suarez1/',
+            calendly: 'https://calendly.com/luis_suarez-berkeley/30min',
+            image: require('../img/prof/Luis.jpg'),
+            sillyImage: require('../img/funny/luis.png'),
             isDM: false
         },
         {
-            name: 'Aditya Dawar',
-            title: 'Senior Associate',
+            name: 'Jules De Boni',
+            title: 'Project Manager',
             bio: [
-                "Hey! My name is Aditya, and I'm currently a sophomore studying Data Science & Legal Studies. I joined NIB just last semester (Spring '25), and I'm so grateful I did. I got the chance both to involve myself in impactful work—my project dealt with reducing maternal mortality in California—and meet an insanely incredible and kind group of people.",
-                "I'm very passionate about civic engagement and technology policy. Outside of NIB, I love everything related to comedy (SNL, sitcoms, etc.), sports (hype for football season), and food (learning to stop eating out and cook my own food, but also I’m always on the hunt for good restaurant recs). Happy to chat about anything, feel free to reach out!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/aditya-dawar/',
-            calendly: 'https://calendar.app.google/maz85GiqR2y8h6YQA',
-            image: require('../img/prof/Adi.jpg'),
-            sillyImage: require('../img/funny/adi.png'),
+             "Hey, what's up! My name is Jules and I'm a junior studying Economics and Data Science. I joined NIB last semester after arriving in the US for the first time, and this is singlehandedly the best decision I've made at Cal. Everything from my first semester's project with Evergreen Goodwill to our insane trip to Mexico has been an insane enhancement of my college experience. I've loved making so many wonderful memories with the people I now call my best friends and I can't wait for you to join the NIBFam!",
+                "Outside of school, I play football/soccer and am part of the Cal Boxing Club. I'm also a big Geography nerd and I love debating about electoral politics and geopolitics, so if you do too, don't hesitate to reach out!!"
+               ],
+            linkedin: 'https://www.linkedin.com/in/jules-de-boni',
+            calendly: 'https://calendly.com/julesdeboni-berkeley/30min',
+            image: require('../img/prof/jules.jpg'),
+            sillyImage: require('../img/funny/jules.png'),
             isDM: false
+        },
+        {
+            name: 'Melanie Davidson',
+            title: 'Project Manager',
+            bio: [
+                "Hi! My name is Mel, and I am a current sophomore, majoring in Cognitive Science and intending to pursue Data Science as well! I joined NIB in my freshman spring and have loved working alongside and learning from the many amazing people in this club, particularly through my project with SFO Airport. However, the NIBfam community extends further than my project, surrounding me with such interesting, dedicated, and kind people that I could not be more grateful for!", 
+                "Besides school, I am on the Club Volleyball team here at Cal, and I enjoy crocheting, reading books about niche scientific topics, trying out new restaurants and cafes with my friends, and running. I am always open to new adventures or anything with good conversation! I can’t wait to meet you!!",
+                "Melanie is studying abroad this semester."
+            ],
+            linkedin: 'https://linkedin.com/in/melanie-davidson-711919325',
+            calendly: 'https://calendly.com/melaniebdavidson-berkeley/30min',
+            image: require('../img/prof/Mel.jpg'),
+            sillyImage: require('../img/funny/mel.png'),
+            isDM: true
         },
         {
             name: 'Kabir Dua',
-            title: 'Senior Associate',
+            title: 'Project Manager',
             bio: [
               "Hi! My name is Kabir, and I am a sophomore studying Data Science and Economics with a minor in Energy & Resources. Joining NIB this past Fall has undoubtedly been one of the most meaningful decisions of my college experience: through NIB, I've found my closest friends, gained invaluable mentors, and learned so much about myself, my true passions, and the intellectually diverse community that surrounds me.", 
                 "This past semester, I was lucky enough to contribute to a waste diversion research project, exploring emerging technologies like physical AI for recycling management and autonomous robotics for plastics sorting, ultimately identifying vendors to help our client, Evergreen Goodwill, achieve their circularity goals for post-consumer materials.",
@@ -193,48 +159,15 @@ let memberInfo = {
             sillyImage: require('../img/funny/kabir.png'),
             isDM: false
         },
-        {
-            name: 'Zoey Bahng',
-            title: 'Returning Associate',
-            bio: [
-               "Hi, this is Zoey! I’m a freshman on the pre-law track studying Political Science and Conservation & Resource Studies. My social impact focus is on environmental justice. I joined NIB my freshman fall and it's been the most well-rounded, supportive community to start college with. When you hear that the NIB community is wholesome, empowering, fun, smart, and genuine, BELIEVE IT!",
-                "Outside of consulting, I intern with Berkeley Law and a wildlife conservation campaign and make content. I'm always down to yap about pinterest boards, science fun facts, matcha cafes, and the political and economic state of the world (ifykyk). So excited to meet you!"
-               ],
-            linkedin: 'https://www.linkedin.com/in/zoeybahng',
-            calendly: 'https://calendly.com/zoeybahng-berkeley',
-            image: require('../img/prof/zoey.jpg'),
-            sillyImage: require('../img/funny/zoey.png'),
-            isDM: false
-        },
-        {
-            name: 'Vit Do',
-            title: 'Returning Associate',
-            bio: [
-               "Hi, I'm Vit! I'm currently studying Economics and Media Studies, and I joined last semester! NIB has been one of my defining experiences at Berkeley, from meeting the most authentic and hardworking people to getting to work on growth and go-to-market strategy with the startup Clutch. The community is one-of-a-kind and there's so many opportunities for deep friendships and mentorship that I'm super grateful for.",
-                "Besides NIB, I've been dancing for 15 years and am currently on Kairos Dance Company, a contemporary group here on campus. Also, in my free time, I love thrifting and crocheting, knitting and sewing my own clothes. Additionally, some artists I listen to are Blood Orange and the Cocteau Twins! You can chat with me about anything, NIB-related or not, so feel free to reach out!"
-               ],
-            linkedin: 'https://www.linkedin.com/in/nguyen-do-61a6a9256/',
-            calendly: 'https://calendly.com/vit-do-berkeley/30min',
-            image: require('../img/prof/vit.jpg'),
-            sillyImage: require('../img/funny/vit.png'),
-            isDM: false
-        },
-        {
-            name: 'Brooklynn Collins',
-            title: 'Returning Associate', 
-            bio: [
-                "Hi! My name is Brook, and I am a sophomore from Los Angeles, majoring in Global Studies and minoring in Public Policy. I joined NIB in Fall '25, and it has been everything I could have hoped for and more. NIB is the sweetest, hardest-working, and most supportive group of people you will EVER find. I have had the opportunity to further my love for #NIBFAM and my technological knowledge through my past project, working with NIB Alum on their start-up, Clutch. I have had the opportunity to grow so much with NIB, not only professionally through our projects but also socially with this group of amazing, diverse individuals.",
-                "Outside of NIB, I am involved with a non-profit organization, ECCO, where I work closely with a team to advance academic justice and opportunities for underprivileged women. I love anything Drake, all music (ESPECIALLY country), sewing, crocheting, and scrapbooking. I can't wait to meet you all, and I am looking forward to talking to you about YOUR interest!!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/brooklynn-collins-70aa22324',
-            calendly: 'https://calendly.com/brooklynn-sc-berkeley/new-meeting?month=2026-01',
-            image: require('../img/prof/brooklynn.jpg'),
-            sillyImage: require('../img/funny/brook.png'),
-            isDM: false
-        },
+    ],
+    pmList: [
+        /* add when we go back to 5 pms lol */
+    ],
+
+    memberList: [
         {
             name: 'Vish Goel',
-            title: 'Returning Associate',
+            title: 'Senior Associate',
             bio: [
               "Hi!! I’m Vish, a freshman from San Jose studying Economics and Political Science. I joined NIB last semester and it’s become one of the communities at Berkeley where I feel most at home— everyone is passionate, kind, and incredibly hard-working. NIB has combined meaningful support and culture with professional development and true impact, and I feel so grateful to be part of such an amazing community. Truly, NIBfam is so real. So far, I’ve worked with a leading guitar company on product strategy and go-to-market for a new audio production software, helping improve user experience and increase access to quality music education with the funniest team #fendysendy.",
                 "I’m passionate about mental health advocacy and economic welfare, specifically in using law to promote preventative care and reduce poverty writ large. Outside of NIB, I love baseball, music (Coldplay, Kendrick, Billy Joel, Maroon 5), working out, binging shows (ATLA, Brooklyn Nine-Nine), and reading political philosophy. I also recently started learning electric guitar. Don’t hesitate to reach out, I’m looking forward to meeting all of you!"
@@ -246,34 +179,21 @@ let memberInfo = {
             isDM: false
         },
         {
-            name: 'Harper Young',
-            title: 'Returning Associate',
+            name: 'Zoey Bahng',
+            title: 'Senior Associate',
             bio: [
-              "Hey there!! My name is Harper Young, I am a freshman studying Environmental Economics and Policy and a returning associate this year. I LOVE NIB, and joining was the best thing I've done at college so far. The people here are the kindest and most genuine people I have ever met, while being the most fun and phenomenal to hang out with. I learned so much from my past project with SC Johnson, but more importantly, forged friendships with nib members who inspire and challenge me every day. #NIBISLITNIBISIT #NIBFAM",
-                "I'm passionate about sustainable development, whether that's regenerative agriculture, restorative infrastructure, energy grids, policy, or habitat conservation. I am also interested in youth literacy, especially for marginalized youth, and advancing equal opportunity in our education systems. Outside of NIB, I love to ski, backpack, hike, cook, and go on any adventure possible (bonus points if someone can teach me how to surf). Please talk to me about whatever gets you excited!!!!!"
+               "Hi, this is Zoey! I’m a freshman on the pre-law track studying Political Science and Conservation & Resource Studies. My social impact focus is on environmental justice. I joined NIB my freshman fall and it's been the most well-rounded, supportive community to start college with. When you hear that the NIB community is wholesome, empowering, fun, smart, and genuine, BELIEVE IT!",
+                "Outside of consulting, I intern with Berkeley Law and a wildlife conservation campaign and make content. I'm always down to yap about pinterest boards, science fun facts, matcha cafes, and the political and economic state of the world (ifykyk). So excited to meet you!"
                ],
-            linkedin: 'https://www.linkedin.com/in/harper-young-2685b6307/',
-            calendly: 'https://calendly.com/harperyoung-berkeley/30min',
-            image: require('../img/prof/harper.png'),
-            sillyImage: require('../img/funny/harper.png'),
-            isDM: false
-        },
-        {
-            name: 'Jules De Boni',
-            title: 'Returning Associate',
-            bio: [
-             "Hey, what's up! My name is Jules and I'm a junior studying Economics and Data Science. I joined NIB last semester after arriving in the US for the first time, and this is singlehandedly the best decision I've made at Cal. Everything from my first semester's project with Evergreen Goodwill to our insane trip to Mexico has been an insane enhancement of my college experience. I've loved making so many wonderful memories with the people I now call my best friends and I can't wait for you to join the NIBFam!",
-                "Outside of school, I play football/soccer and am part of the Cal Boxing Club. I'm also a big Geography nerd and I love debating about electoral politics and geopolitics, so if you do too, don't hesitate to reach out!!"
-               ],
-            linkedin: 'https://www.linkedin.com/in/jules-de-boni',
-            calendly: 'https://calendly.com/julesdeboni-berkeley/30min',
-            image: require('../img/prof/jules.jpg'),
-            sillyImage: require('../img/funny/jules.png'),
+            linkedin: 'https://www.linkedin.com/in/zoeybahng',
+            calendly: 'https://calendly.com/zoeybahng-berkeley',
+            image: require('../img/prof/zoey.jpg'),
+            sillyImage: require('../img/funny/zoey.png'),
             isDM: false
         },
         {
             name: 'Vedatman Duhoon',
-            title: 'Returning Associate',
+            title: 'Senior Associate',
             bio: [
                 "Hello everyone! I'm Vedatman, a freshman studying Business. I joined NIB last fall, and it’s been one of the best decisions I could’ve made! From day one, I was welcomed into the most inspiring, uplifting and genuine community on campus. Beyond the people, NIB has also provided me with an incredible environment for professional growth and exploration. Through my project with SC Johnson, I had the opportunity to dive into ESG reports, analyze sustainability initiatives, and think critically about how large corporations approach social and environmental impact. Outside of NIB, I love playing board games, watching soccer (FC Barcelona fan), and following Formula 1!"
             ],
@@ -284,8 +204,89 @@ let memberInfo = {
             isDM: false
         },
         {
+            name: 'Vit Do',
+            title: 'Senior Associate',
+            bio: [
+               "Hi, I'm Vit! I'm currently studying Economics and Media Studies, and I joined last semester! NIB has been one of my defining experiences at Berkeley, from meeting the most authentic and hardworking people to getting to work on growth and go-to-market strategy with the startup Clutch. The community is one-of-a-kind and there's so many opportunities for deep friendships and mentorship that I'm super grateful for.",
+                "Besides NIB, I've been dancing for 15 years and am currently on Kairos Dance Company, a contemporary group here on campus. Also, in my free time, I love thrifting and crocheting, knitting and sewing my own clothes. Additionally, some artists I listen to are Blood Orange and the Cocteau Twins! You can chat with me about anything, NIB-related or not, so feel free to reach out!"
+               ],
+            linkedin: 'https://www.linkedin.com/in/nguyen-do-61a6a9256/',
+            calendly: 'https://calendly.com/vit-do-berkeley/30min',
+            image: require('../img/prof/vit.jpg'),
+            sillyImage: require('../img/funny/vit.png'),
+            isDM: false
+        },
+        {
+            name: 'Dia Hemanth',
+            title: 'Returning Associate',
+            bio: [
+                "Hi! My name is Dia, and I’m a freshman studying Business with a minor in Data Science. Throughout my first semester, I was looking for a community I could call home, somewhere that would make Berkeley feel a little smaller. NIB has given me that and so much more; I’ve truly found a family here!",
+                "I love being surrounded by people who are so passionate and willing to uplift and challenge one another to grow.",
+                "I’m especially passionate about personal finance and closing the financial literacy gap. In the past, I founded a financial literacy nonprofit where I developed my own personal finance curriculum and led workshops for students.",
+                "Outside of NIB, I enjoy baking, listening to British rap (some of my favorite artists are Dave, Central Cee, J Hus, and AJ Tracey), doing Pilates, and exploring new coffee spots. I can’t wait to meet you, so don’t hesitate to reach out!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/diahemanth/',
+            calendly: '',
+            image: require('../img/prof/dia.jpg'),
+            sillyImage: require('../img/funny/dia.jpg'),
+            isDM: false
+        },
+        {
+            name: 'Sid Avula',
+            title: 'Returning Associate',
+            bio: [
+                "Hey! I'm Sid, a freshman studying Business Administration from Chicago, IL. I joined NIB in SP '26 and #NIBFam has provided me with a supportive and genuinely fun community that feels like a home away from home. Additionally, I've never met a group of people so passionate about creating an impact in the world, no matter what field or cause. There's such a diverse range of perspectives in NIB, and it's refreshing to learn from people who think differently and are driven by their own passions. I'm particularly interested in alleviating global hygiene and period poverty, and I'm excited to keep expanding that impact by applying the skills and insights I gain through NIB.",
+                "Outside of NIB, I've played soccer my whole life, and it's been a huge part of shaping who I am - from competitiveness and discipline to just loving to be active. I'm also big on country music, exploring new hiking trails, and playing new sports. Lately, I've also been on a mission to finally learn how to swim. Excited to get to know everyone!"
+                ],
+            linkedin: 'https://www.linkedin.com/in/siddharthavula/',
+            calendly: '',
+            image: require('../img/prof/sid.jpg'),
+            sillyImage: require('../img/funny/sid.jpg'),
+            isDM: false
+        },
+        {
+            name: 'Dylan Gunadi',
+            title: 'Returning Associate',
+            bio: [
+                "Hey! I’m Dylan, a freshman studying DS + Econ coming from Jakarta, Indonesia! I joined NIB Spring ‘26, and it was probably one of the most influential decisions I’ve made. I remember just how confusing it was coming from 8,000 miles away to such a big university with one too many clubs on sproul… If that’s you, or even if it’s not, this is by far the most wholesome, supportive, and social community to join (no glaze pure honesty).",
+                "I am most passionate about education, nutrition, and men’s mental health and have experience working with systems back home to uplift the underserved. Aside from social impact and consulting, I love anything sports/outdoors (hoops, surfing, skiing, running, lifting), reading non-performatively, and eating insane amts of food.",
+                "I’m super excited to meet all you guys, reach out and let’s talk about intl. experience, shower thoughts, life, the nba, anything."
+                ],
+            linkedin: 'https://www.linkedin.com/in/dylan-gunadi/',
+            calendly: '',
+            image: require('../img/prof/dylan.jpg'),
+            sillyImage: require('../img/funny/vedatman.png'),
+            isDM: false
+        },
+        {
+            name: 'Lilliana Calvert',
+            title: 'Returning Associate',
+            bio: [
+                "Hi! I’m Lilliana, a freshman studying Business Administration and Data Science from Western Washington. Joining NIB this semester has honestly been one of the best decisions I could have possibly made. It has pushed me to be far more intentional about how I learn, who I learn from, and the kinds of problems I want to work on. I’m excited to keep building practical skills and use NIB as a space to test out different directions and passions.",
+                "Outside of NIB, I’m really interested in building and startups, especially in sustainable business, clean tech, SaaS, and materials engineering. I also enjoy absolutely anything creative (creative engineering, watercolors, fashion, etc.). Outside of school and projects, I love pilates (shoutout to the lovely bodyrok), hiking (Washington trails > any other trails in the world), baking (currently learning how to make croissants), and reading (if you ever need recommendations, let me know!)",
+            ],
+            linkedin: 'https://www.linkedin.com/in/lillianakcalvert/',
+            calendly: '',
+            image: require('../img/prof/lilliana.jpg'),
+            sillyImage: require('../img/funny/lilliana.jpg'),
+            isDM: false
+        },
+        {
+            name: 'Ayla Margate',
+            title: 'Returning Associate',
+            bio: [
+                "Hi! I'm Ayla, a freshman majoring in Business Administration in Haas' 4- year Spieker program and minoring in Public Policy, and am from Walnut Creek in the East Bay. I joined Net Impact in Spring of 2026 and have been absolutely loving every second so far. Even though it's only my first semester, I can easily call the people I've met in NIB some of my closest friends. The family I've been welcomed into has been filled with lots of love, surprises, and endless fun. Each person in NIB has a social impact area they are passionate about, from education to women's advocacy, and I've loved learning about everyone's passions. Personally, I am passionate about education equity and civic engagement, and am looking forward to the ways I can integrate these passions into future projects. This semester, I am working with the California Academy of Sciences to expand corporate philanthropy and donors to fun STEM educational experiences to museum visitors. I grew up going to the museum so I am very excited to be working with them!",
+                "Outside of NIB, I'm involved in the ASUC where I serve as an associate under the Office of the President. I enjoy going on daily walks, working out and playing sports, baking, shopping (downtown WC is where it's at!), and trying new food spots around Berkeley! I can't wait to meet all of you and share more about my experiences in NIB!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/ayla-margate-4bb395381/',
+            calendly: '',
+            image: require('../img/prof/ayla.jpg'),
+            sillyImage: require('../img/funny/ayla.jpg'),
+            isDM: false
+        },
+        {
             name: 'Erica Chen',
-            title: 'Associate',
+            title: 'Returning Associate',
             bio: [
                 "Hi! I’m Erica, a freshman majoring in Business Administration and Legal Studies with a minor in Data Science from Vancouver, Canada.",
                 "As someone who joined NIB just this past semester, I’ve been able to see a clear difference between my life at Cal before and after becoming part of this community. Arriving as an international student, I was honestly overwhelmed by the sheer number of opportunities and groups on campus. It was exciting, but I also felt lost at times, unsure of where I truly belonged. From the moment I joined NIB, that changed. With NIB, I not only tried In-N-Out for the first time (and yes, animal style fries really might beat poutine), but I also found an incredibly intellectually diverse group of people who genuinely care about using business as a force for good, along with the warmest, most supportive family I could have asked for.",
@@ -301,62 +302,21 @@ let memberInfo = {
             isDM: false
         },
         {
-            name: 'Lilliana Calvert',
-            title: 'Associate',
+            name: 'Anthony Sapp Guadarrama',
+            title: 'Returning Associate',
             bio: [
-                "Hi! I’m Lilliana, a freshman studying Business Administration and Data Science from Western Washington. Joining NIB this semester has honestly been one of the best decisions I could have possibly made. It has pushed me to be far more intentional about how I learn, who I learn from, and the kinds of problems I want to work on. I’m excited to keep building practical skills and use NIB as a space to test out different directions and passions.",
-                "Outside of NIB, I’m really interested in building and startups, especially in sustainable business, clean tech, SaaS, and materials engineering. I also enjoy absolutely anything creative (creative engineering, watercolors, fashion, etc.). Outside of school and projects, I love pilates (shoutout to the lovely bodyrok), hiking (Washington trails > any other trails in the world), baking (currently learning how to make croissants), and reading (if you ever need recommendations, let me know!)",
-            ],
-            linkedin: 'https://www.linkedin.com/in/lillianakcalvert/',
-            calendly: '',
-            image: require('../img/prof/lilliana.jpg'),
-            sillyImage: require('../img/funny/lilliana.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Dia Hemanth',
-            title: 'Associate',
-            bio: [
-                "Hi! My name is Dia, and I’m a freshman studying Business with a minor in Data Science. Throughout my first semester, I was looking for a community I could call home, somewhere that would make Berkeley feel a little smaller. NIB has given me that and so much more; I’ve truly found a family here!",
-                "I love being surrounded by people who are so passionate and willing to uplift and challenge one another to grow.",
-                "I’m especially passionate about personal finance and closing the financial literacy gap. In the past, I founded a financial literacy nonprofit where I developed my own personal finance curriculum and led workshops for students.",
-                "Outside of NIB, I enjoy baking, listening to British rap (some of my favorite artists are Dave, Central Cee, J Hus, and AJ Tracey), doing Pilates, and exploring new coffee spots. I can’t wait to meet you, so don’t hesitate to reach out!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/diahemanth/',
-            calendly: '',
-            image: require('../img/prof/dia.jpg'),
-            sillyImage: require('../img/funny/dia.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Ayla Margate',
-            title: 'Associate',
-            bio: [
-                "Hi! I'm Ayla, a freshman majoring in Business Administration in Haas' 4- year Spieker program and minoring in Public Policy, and am from Walnut Creek in the East Bay. I joined Net Impact in Spring of 2026 and have been absolutely loving every second so far. Even though it's only my first semester, I can easily call the people I've met in NIB some of my closest friends. The family I've been welcomed into has been filled with lots of love, surprises, and endless fun. Each person in NIB has a social impact area they are passionate about, from education to women's advocacy, and I've loved learning about everyone's passions. Personally, I am passionate about education equity and civic engagement, and am looking forward to the ways I can integrate these passions into future projects. This semester, I am working with the California Academy of Sciences to expand corporate philanthropy and donors to fun STEM educational experiences to museum visitors. I grew up going to the museum so I am very excited to be working with them!",
-                "Outside of NIB, I'm involved in the ASUC where I serve as an associate under the Office of the President. I enjoy going on daily walks, working out and playing sports, baking, shopping (downtown WC is where it's at!), and trying new food spots around Berkeley! I can't wait to meet all of you and share more about my experiences in NIB!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/ayla-margate-4bb395381/',
-            calendly: '',
-            image: require('../img/prof/ayla.jpg'),
-            sillyImage: require('../img/funny/ayla.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Sid Avula',
-            title: 'Associate',
-            bio: [
-                "Hey! I'm Sid, a freshman studying Business Administration from Chicago, IL. I joined NIB in SP '26 and #NIBFam has provided me with a supportive and genuinely fun community that feels like a home away from home. Additionally, I've never met a group of people so passionate about creating an impact in the world, no matter what field or cause. There's such a diverse range of perspectives in NIB, and it's refreshing to learn from people who think differently and are driven by their own passions. I'm particularly interested in alleviating global hygiene and period poverty, and I'm excited to keep expanding that impact by applying the skills and insights I gain through NIB.",
-                "Outside of NIB, I've played soccer my whole life, and it's been a huge part of shaping who I am - from competitiveness and discipline to just loving to be active. I'm also big on country music, exploring new hiking trails, and playing new sports. Lately, I've also been on a mission to finally learn how to swim. Excited to get to know everyone!"
+                "Hi! I’m Anthony, a freshman studying Economics and minoring in Data Science and GPP from San Diego. I joined this semester and have loved the vibrant and genuine community that comes with NIB. The sense of community is unmatched and I’ve never been prouder to share a group of passionate people than ever before. I’m currently working on a project with Logitech and have grown so much in the past couple of first weeks and so can you!",
+                "I’m passionate about mitigating world poverty and creating a more equitable and sustainable future. Outside of NIB, I love to play squash, find new places to eat on Fat Sundays, watch movies, and thrift. I’m a part of FAST and love fashion, so coffee chat me in your toughest fit! I love to talk to people who are excited about their passions! Can’t wait to meet you!",
                 ],
-            linkedin: 'https://www.linkedin.com/in/siddharthavula/',
+            linkedin: 'https://www.linkedin.com/in/anthony-sapp-guadarrama-196239335/',
             calendly: '',
-            image: require('../img/prof/sid.jpg'),
-            sillyImage: require('../img/funny/sid.jpg'),
+            image: require('../img/prof/anthony.jpg'),
+            sillyImage: require('../img/funny/anthony.jpg'),
             isDM: false
         },
         {
             name: 'Amy Tanaka',
-            title: 'Associate',
+            title: 'Returning Associate',
             bio: [
                 "Hai I’m Amy and I’m a freshman studying environmental engineering science! Joining NIB has been the highlight of my semester and I’m so excited for this journey. I really love the #NIBFAM and how everyone’s so genuine, passionate, and a little bit quirky!",
                 "I’m extremely passionate about environmental justice, specifically building sustainable infrastructure in low-income neighborhoods and developing countries.",
@@ -369,136 +329,95 @@ let memberInfo = {
             isDM: false
         },
         {
-            name: 'Dylan Gunadi',
-            title: 'Associate',
-            bio: [
-                "Hey! I’m Dylan, a freshman studying DS + Econ coming from Jakarta, Indonesia! I joined NIB Spring ‘26, and it was probably one of the most influential decisions I’ve made. I remember just how confusing it was coming from 8,000 miles away to such a big university with one too many clubs on sproul… If that’s you, or even if it’s not, this is by far the most wholesome, supportive, and social community to join (no glaze pure honesty).",
-                "I am most passionate about education, nutrition, and men’s mental health and have experience working with systems back home to uplift the underserved. Aside from social impact and consulting, I love anything sports/outdoors (hoops, surfing, skiing, running, lifting), reading non-performatively, and eating insane amts of food.",
-                "I’m super excited to meet all you guys, reach out and let’s talk about intl. experience, shower thoughts, life, the nba, anything."
-                ],
-            linkedin: 'https://www.linkedin.com/in/dylan-gunadi/',
-            calendly: '',
-            image: require('../img/prof/dylan.jpg'),
-            sillyImage: require('../img/funny/vedatman.png'),
-            isDM: false
-        },
-        {
-            name: 'Anthony Sapp Guadarrama',
-            title: 'Associate',
-            bio: [
-                "Hi! I’m Anthony, a freshman studying Economics and minoring in Data Science and GPP from San Diego. I joined this semester and have loved the vibrant and genuine community that comes with NIB. The sense of community is unmatched and I’ve never been prouder to share a group of passionate people than ever before. I’m currently working on a project with Logitech and have grown so much in the past couple of first weeks and so can you!",
-                "I’m passionate about mitigating world poverty and creating a more equitable and sustainable future. Outside of NIB, I love to play squash, find new places to eat on Fat Sundays, watch movies, and thrift. I’m a part of FAST and love fashion, so coffee chat me in your toughest fit! I love to talk to people who are excited about their passions! Can’t wait to meet you!",
-                ],
-            linkedin: 'https://www.linkedin.com/in/anthony-sapp-guadarrama-196239335/',
-            calendly: '',
-            image: require('../img/prof/anthony.jpg'),
-            sillyImage: require('../img/funny/anthony.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Aswin Surya', 
+            name: 'Diane Shih', 
             title: 'Senior Advisor',
             bio: [
-                "Hey! I'm Aswin, a sophomore from the Bay Area studying EECS. I joined NIB freshman fall, and it is honestly the best decision I've made at Berkeley. In the last year, NIB has given me so many opportunities, from a free Michelin dinner to presenting global health strategy to the United Nations in DC to meeting the most amazing community on campus. I'm particularly passionate about healthcare, and the intersection of tech and health, using digital tools to ensure quality and accessible healthcare for all.",
-                "I'm also on leadership in Dil Se, Berkeley's South Asian A Cappella Team and am in Berkeley AI Research, where I work on hybrid systems, LLMs, and cybersecurity.",
-                "Outside of NIB, I love lifting, listening to any and all types of music, and playing basketball and tennis. My goal is to try every single food place at Berkeley, so if you have any unique favorites, don't hesitate to hit me up. Looking forward to chatting with you :)"],
-            linkedin: 'https://www.linkedin.com/in/aswinsurya/',
-            calendly: 'https://calendly.com/aswinsurya/nib-coffee-chats',
-            image: require('../img/prof/Aswin.jpg'),
-            sillyImage: require('../img/funny/aswin.png'),
-            isDM: false
-        },
-       
-        {
-            name: 'Luis Suarez',
-            title: 'Senior Advisor',
-            bio: [
-              "Hello there!!! My name is Luis, and I am a Sophomore studying Business & Compsci!!! I just joined NIB last semester (Spring 2025), and it has been one of the best decisions I have made in college so far. NIB has provided me with a strong professional exposure to the Business world while having a solid social impact foundation. This passion for social impact is visible through the culture in the club, the projects we undertake, and our members' lives outside of NIB. I cannot wait to see how this club continues to grow as we welcome a new class. In just a semester, NIB has become a family to me, and I would love to see that happen in others as well.",
-              "If you have any questions, please do not hesitate to reach out!!! Goodluck :DDDD"],
-            linkedin: 'https://www.linkedin.com/in/luis-suarez1/',
-            calendly: 'https://calendly.com/luis_suarez-berkeley/30min',
-            image: require('../img/prof/Luis.jpg'),
-            sillyImage: require('../img/funny/luis.png'),
-            isDM: false
-        },
-        {
-            name: 'Maitree Meher',
-            title: 'Senior Advisor',
-            bio: [
-                "Hey! I am Maitree & I am a junior studying EECS & Business. This past semester has been my best one at Berkeley, and NIB was the biggest reason why. The community here is incredible, I’ve built some of my closest friendships through it, I have so many wonderful memories with NIB & my fav one has to be wave crashing with my project team (Environmental Defense Fund) in Hawaii. I’m so grateful for everything I’ve experienced with NIB; it’s made my time at Berkeley more meaningful, and so much more fun.",
-                "Outside of NIB, I am interested in research and interned as a Quant Researcher at Squarepoint in London this summer. I am involved in M.E.T., CIB, and recently got into running. Excited to meet you this semester!]"
+                "Hi! I'm Diane, and I'm a third year studying Business, Cognitive Science, and Data Science. I joined NIB during my freshman spring semester and have truly loved every second! NIB is such an amazing and supportive community, and I've felt so very lucky to be a part of it. During my time with NIB, I've worked with a global edTech company on AI strategy, the World Bank on WASH financing, and the Environmental Defense Fund on cost-benefit analysis of wildfire treatments (super cool and awesome stuff!!).",
+                "I'm very passionate about neurodiversity, education, and environmental sustainability, and NIB has helped me further these passions through the unique, genuine, and impactful work that we do. Feel free to reach out if you want to talk about any and all things music, really terrible puns/dad jokes, travel (yet having no sense of direction), questions about NIB, or really anything you want!",
             ],
-            linkedin: 'https://www.linkedin.com/in/maitreemeher/',
-            calendly: 'https://calendly.com/maitree-meher-berkeley/nib-calendly',
-            image: require('../img/prof/Maitree.jpg'),
-            sillyImage: require('../img/funny/maitree.png'),
+            linkedin: 'https://www.linkedin.com/in/diane-shih',
+            image: require('../img/prof/Diane.jpg'),
+            sillyImage: require('../img/funny/dgshih.png'),
+            isDM: true
+        },
+        {
+            name: 'Tanya Chandok',
+            title: 'Senior Advisor',
+            bio: [
+               "Hey! I'm Tanya, a junior majoring in Molecular & Cellular Biology and Economics from Vancouver, Canada. Joining NIB has been an incredible journey and it’s truly my second family on campus, providing me with endless opportunities for growth and some of the most amazing friendships I could ask for. My past projects have included working with a consumer tech-focused venture capital fund to analyze investment opportunities in Latin America's rapidly evolving digital landscape, as well as with a leading geothermal energy company to identify strategic partnerships to expand their global footprint and advancing sustainable energy solutions.",
+                "I am deeply passionate about addressing water accessibility challenges and I have channeled that passion by developing low-cost water purification methods and leading initiatives to educate and empower remote Indigenous communities with sustainable and culturally informed solutions.",
+                "Outside of NIB, tennis has been a central part of my life. I’ve been playing and directing tennis programs for 12 years and it’s shaped so much of who I am! I am involved in tumor immunotherapy research, exploring strategies to combat cancer and improve patient outcomes. I’m also a member of Alpha Delta Pi, where I’ve led Diversity, Equity, and Inclusion initiatives across Greek life, working to foster a more inclusive and welcoming community on campus. In my free time, I love shopping (NIB’s Aritzia plug), pilates (I’m practically my studio’s unofficial ambassador), and cooking (I make a mean Nobu Tuna Crispy Rice dupe).",
+                "Can't wait to meet you and share more about the amazing experiences NIB has to offer!",
+            ],
+            linkedin: 'https://www.linkedin.com/in/tanyachandok/',
+            calendly: 'https://calendly.com/tanyachandok-berkeley/coffee-chats',
+            image: require('../img/prof/tanya.jpg'),
+            sillyImage: require('../img/funny/tanya.png'),
+            isDM: true
+        },
+        {
+            name: 'Maddie Bhuvan', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hey! I’m Maddie, an intended Business, Psychology, and Cognitive Science major, and this is my third semester in NIB. I am so grateful for the amazing memories I’ve made so far; this club has brought me some of my closest friends!",
+                "I am very passionate about LGBTQ+ inclusivity, educational accessibility, environmental sustainability, and mental health awareness. Outside of NIB, I love to dance, take cool pictures, sing, hike, collect matchboxes, and play the drums. I’m also always on the lookout for good music, thrift stores, food, and boba/matcha (pmo if you have recs please)!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/madhurum-bhuvan',
+            image: require('../img/prof/maddie.jpg'),
+            sillyImage: require('../img/funny/madhurum.png'),
+            isDM: true
+        },
+        {
+            name: 'Javier Gonzales',
+            title: 'Senior Advisor',
+            bio: [
+               "Hi! I'm Javi, currently a Junior studying EECS. I've been in NIB for a couple semesters now and I haven't looked back since! NIB has been an amazing place for me to learn much more outside of my traditional coursework and take on meaningful work that truly does have an impact. I've met so many new and amazing people that truly inspire me everyday.", 
+               "Outside of NIB I love folding clothes, playing soccer, watching gorilla videos, backpacking, and baked goods."
+            ],
+            linkedin: 'https://www.linkedin.com/in/javiercgonzales',
+            calendly: 'https://calendly.com/javiergonzales-berkeley/30min',
+            image: require('../img/prof/javi.jpg'),
+            sillyImage: require('../img/funny/javi.png'),
+            isDM: true
+        },
+        {
+            name: 'Anika Yu',
+            title: 'Senior Advisor',
+            bio: [
+                "Hi, I’m Anika and I’m a sophomore studying Political Economy, Data Science, and Public Policy. I joined NIB my freshman spring (SP25 CLASS ON TOP!) and could not have been more grateful for the memories I've gained, coming up on one year in the club. NIB not only broadened my concept of what my academic and professional career could look like, but also provided me with the most supportive and sweet friends ever. I can never shut my mouth around them, whether it's presenting a deliverable to a nonprofit CEO or making up a derpy language that only my team understands #fendyforever.",
+                "I am super passionate about equitable policymaking and participatory democracy, especially in the field of education. Ultimately, I want to be a public interest lawyer! I'd love to talk about how my previous projects, Pro Bono Institute and Fender, have intersected with these passions. We can also connect over cool books, elite food spots, and recent budding interests (mine are running and F1!)",
+                "There is never a dull moment in NIB and I am so excited for you to discover what that could look like for yourself through recruitment!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/anika-yu/',
+            calendly: 'https://calendly.com/anika-yu/nib-spring-26-coffee-chats-anika',
+            image: require('../img/prof/Anika.jpg'),
+            sillyImage: require('../img/funny/anika.png'),
             isDM: false
         },
         {
-            name: 'Brian Poh',
+            name: 'Aditya Dawar',
             title: 'Senior Advisor',
             bio: [
-                "Hey I'm Brian and I'm currently a junior studying Analytics. I joined NIB my sophomore spring semester and it has really made my experience at Cal more fulfilling and memorable. My prior project experience working with the Environmental Defense Fund allowed me to help develop data-driven wildfire resilience strategies based on grant trend analysis.",
-                "I'm interested in exploring current regulated hospitality practices and standards to advance eco-tourism and sustainable development. In the past, I have also volunteered in Cambodia and Southern Taiwan, specifically focusing on supporting local initiatives that strive to improve the quality of education.", 
-                "In my free time I like to play sports, watch Netflix, cook, travel, and spend quality time with my friends and family. Don't hesitate to reach out!]"
+                "Hey! My name is Aditya, and I'm currently a sophomore studying Data Science & Legal Studies. I joined NIB just last semester (Spring '25), and I'm so grateful I did. I got the chance both to involve myself in impactful work—my project dealt with reducing maternal mortality in California—and meet an insanely incredible and kind group of people.",
+                "I'm very passionate about civic engagement and technology policy. Outside of NIB, I love everything related to comedy (SNL, sitcoms, etc.), sports (hype for football season), and food (learning to stop eating out and cook my own food, but also I’m always on the hunt for good restaurant recs). Happy to chat about anything, feel free to reach out!"
             ],
-            linkedin: 'https://www.linkedin.com/in/brian-poh-b8686637b/',
-            calendly: 'https://calendly.com/brianpoh/brian-nib-spring-26-coffee-chats',
-            image: require('../img/prof/Brian.jpg'),
-            sillyImage: require('../img/funny/brian.png'),
+            linkedin: 'https://www.linkedin.com/in/aditya-dawar/',
+            calendly: 'https://calendar.app.google/maz85GiqR2y8h6YQA',
+            image: require('../img/prof/Adi.jpg'),
+            sillyImage: require('../img/funny/adi.png'),
             isDM: false
         },
         {
-            name: 'Wenhan Xi', 
-            title: 'Senior Advisor',
+            name: 'Brooklynn Collins',
+            title: 'Senior Advisor', 
             bio: [
-                "Hi there! I’m Han, and I’m a Senior studying econ and data science. I joined NIB freshman fall and it's here that I've found a home. So far, I've had the privilege to work on amazing projects from developing social enterprise partnership strategies for the aerospace industry to digital readiness with farmers and even on a corporate partnership strategy for an environmental advocacy group. Last year, I led my own project supporting the World Bank's efforts in promoting Water and Sanitation investment, before serving as NIB's VP Consulting and President.",
-                "Outside of NIB, I love judo, building houses and cooking up a storm in the kitchen (cleaning up after though is something I'm still working on...) I’m super excited to meet you through recruitment this Spring!"
-               ],
-            linkedin: 'https://www.linkedin.com/in/wenhanxi/',
-            calendly: 'https://calendar.app.google/d2n8TsidFUFbzFD29',
-            image: require('../img/prof/Han.jpg'),
-            sillyImage: require('../img/funny/han.png'),
-            isDM: false
-         },
-         {
-            name: 'Breanna Pearlman', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hi! I’m Breanna, and I’m a senior studying Global Studies and Political Science with a minor in Human Rights. I joined NIB my freshman spring, and it has been the best decision I’ve made! In my short time in NIB so far I have already made such amazing memories and met some of my closest friends. In the past, I’ve worked on social impact initiative ideation for a leading energy bar company and food safety testing implementation for the Global Alliance for Improved Nutrition. Last semester, I co-led a project in partnership with the Hunger Project that focused on expanding the organization's youth programs.", 
-                "Outside of consulting, I am interested in human rights, environmental justice, African development, and Timothée Chalamet. I am also involved in on-campus research. In my free time, I love shopping, hiking, and traveling. I just got back from a semester abroad in Paris in the spring. Feel free to reach out and chat, and I look forward to meeting you! Feel free to reach out and chat, and I look forward to meeting you!"
+                "Hi! My name is Brook, and I am a sophomore from Los Angeles, majoring in Global Studies and minoring in Public Policy. I joined NIB in Fall '25, and it has been everything I could have hoped for and more. NIB is the sweetest, hardest-working, and most supportive group of people you will EVER find. I have had the opportunity to further my love for #NIBFAM and my technological knowledge through my past project, working with NIB Alum on their start-up, Clutch. I have had the opportunity to grow so much with NIB, not only professionally through our projects but also socially with this group of amazing, diverse individuals.",
+                "Outside of NIB, I am involved with a non-profit organization, ECCO, where I work closely with a team to advance academic justice and opportunities for underprivileged women. I love anything Drake, all music (ESPECIALLY country), sewing, crocheting, and scrapbooking. I can't wait to meet you all, and I am looking forward to talking to you about YOUR interest!!"
             ],
-            linkedin: 'https://www.linkedin.com/in/breanna-pearlman-637119251/',
-            calendly: 'https://calendly.com/breannapearlman/nib-spring-26-coffee-chats?month=2026-01',
-            image: require('../img/prof/bre.jpg'),
-            sillyImage: require('../img/funny/breanna.png'),
-            isDM: false
-        },
-        
-        {
-            name: 'Madelyn Christensen',
-            title: 'Senior Advisor',
-            bio: [
-                "Hello! I'm Madelyn, a senior studying Cognitive Science & Data Science. Since joining NIB in 2022, I've had the opportunity to work on a wide range of exciting projects with some of the largest non-profits in the world on the global healthcare crisis. I also had the opportunity to lead my own team on a project about AI usage in universities, partnering with a leading AI detection company.",
-                "Outside of NIB, you can find me reading on the glade, dancing with some of Cal's dance teams, exploring coffee shops, or debating. NIB has given me a wide range of experiences and opportunities that I never could've imagined. But more than any of that, it's given me a truly amazing community here on Berkeley's campus to connect with. So much love for NIBFAM!!",
-            ],
-            linkedin: 'https://www.linkedin.com/in/madelynchristensen/',
-            calendly: 'https://calendly.com/madelync-1/nib-fall-2024-coffee-chats',
-            image: require('../img/prof/Madelyn Christensen.jpg'),
-            sillyImage: require('../img/funny/madelyn.png'),
-            isDM: false
-        },
-        {
-            name: 'Srijani Sarkar', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hi! Im Srijani, a senior majoring in MEB & Cognitive Science. Joining NIB was an amazing decision, and the people I met quickly became family. I've had the privilege of working on two projects, TurtleTree and Diageo, and leading one with SFO.",
-                "Outside of NIB, I am a member of PhiDE, a pre medical fraternity, and plan on going into Life Sciences consulting before attending medical school. Talk to me about anything sports related (I play IM basketball & club lacrosse at Berkeley, and work for the athletic department), going abroad/traveling (I studied in Madrid last fall), or about concerts and music (some favs are Daniel Caesar, Mac Demarco, Gunna, SZA, Joey Bada$$, Chris Stapleton)"
-            ],
-            calendly: 'https://calendly.com/srijani-sarkar/nib-coffee-chats',
-            linkedin: 'https://www.linkedin.com/in/srijani-sarkar-035016200/',
-            image: require('../img/prof/srijani.jpg'),
-            sillyImage: require('../img/funny/srijani.jpeg'),
+            linkedin: 'https://www.linkedin.com/in/brooklynn-collins-70aa22324',
+            calendly: 'https://calendly.com/brooklynn-sc-berkeley/new-meeting?month=2026-01',
+            image: require('../img/prof/brooklynn.jpg'),
+            sillyImage: require('../img/funny/brook.png'),
             isDM: false
         },
         {
@@ -515,32 +434,6 @@ let memberInfo = {
             isDM: false
         },
         {
-            name: 'Nikith Vangala',
-            title: 'Senior Advisor',
-            bio: [
-                "Hi! It's great to meet you :) My name is Nikith and I'm a senior studying EECS and Business. I'm going to be a senior advisor this semester, and have served as VP Finance & Operations and President over the past few semesters.",   
-                "NIB has been my home away from home since my first semester at school. I've met my closest friends and roommates through this club and I couldn't be more thankful for all the opportunities it's provided me. I've worked on four projects so far: roadmapping health product procurement in Africa for one of the largest nonprofit orgs in the world, growth strategy for a sustainable clothing retailer, a go-to-market strategy for a new biotechnology startup with a sustainable alternative to a milk derivative, and building a recognition algorithm for a stealth-stage startup.",
-                "I am also a member of UCB Zahanat, a Bollywood fusion dance team here on campus."
-            ],
-            linkedin: 'https://linkedin.com/in/nikith-vangala',
-            calendly: 'https://calendly.com/nikith-vangala/nib-coffee-chats',
-            image: require('../img/prof/Nikith.jpg'),
-            sillyImage: require('../img/funny/nikith.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Sashank Gadisetti', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hello! I'm Sashank and I am currently a senior studying computer science. I joined NIB my junior fall and it's been an amazing experience so far. I've had the opportunity to work with a sustainable fashion company looking to expand into the EU so far. I personally am passionate about personalized, accessible education everywhere. I've had an amazing experience in NIB so far and I'm super excited for what the semester has in store. Super excited to meet everyone!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/sashank-gadisetti',
-            calendly: 'https://calendly.com/sgadisetti-berkeley/coffee-chats',
-            image: require('../img/prof/Sashank.jpg'),
-            sillyImage: require('../img/funny/sashank.png'),
-            isDM: false
-        },
-        {
             name: 'Raymond Yuan', 
             title: 'Senior Advisor',
             bio: [
@@ -553,7 +446,7 @@ let memberInfo = {
             image: require('../img/prof/raymond.png'),
             sillyImage: require('../img/funny/raymond.png'),
             isDM: false
-        }, 
+        },
         {
             name: 'Grayson Peters',
             title: 'Senior Advisor',
@@ -563,111 +456,9 @@ let memberInfo = {
             ],
             linkedin: 'https://www.linkedin.com/in/graybert',
             calendly: 'https://calendly.com/graybert-berkeley/30min',
-            image: require('../img/prof/grayson.jpg'),
+            image: require('../img/prof/Grayson.jpg'),
             sillyImage: require('../img/funny/grayson.png'),
             isDM: false
-        },
-        {
-            name: 'Elan Trager', 
-            title: 'Senior Advisor',
-            bio: [
-                    "Hello! I'm Elan, a senior studying Environmental Econ and Data Science. As I enter my sixth semester in NIB, I have nothing but love for everyone in this org. Throughout my time here I’ve gotten to work with recognizable companies on relevant sustainability efforts, while increasingly becoming closer to this amazing community. I cannot wait to welcome in our next round of Niblets!",
-                    "In my free time I can be found at the climbing gym (shoutout Mosaic), RSF, being a tad too competitive on our NIB IM sports teams, or laying on the glade in the sun with some still woozy playing."],
-            linkedin: 'https://www.linkedin.com/in/elan-trager-a9a2311a9/',
-            calendly: 'https://calendly.com/elantrager/nib-coffee-chatsky',
-            image: require('../img/prof/elan.jpg'),
-            sillyImage: require('../img/funny/elan.png'),
-            isDM: false
-        },
-        {
-            name: 'Grace Hu', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hi, I’m Grace! I’m a fourth-year from Shanghai majoring in Political Economy and Economics, with minors in Public Policy and Data Science. I joined NIB in Fall ’23, and it’s become a quintessential part of my college experience.",
-                "In NIB, I’ve served as VP of Finance and Operations, led a project with one of the world’s largest humanitarian NGOs, and worked with both a multinational corporation to enhance its sustainability program and a direct-air-capture climate tech company on growth strategy.",
-                "As a first-generation college student, I’m deeply passionate about poverty alleviation and global development. Outside of NIB, I’m heavily involved in social science research, love spontaneous midnight drives, savor a great meal, and enjoy solo traveling. Excited to meet you all soon!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/gracexyhu/',
-            calendly: 'https://calendly.com/grace_hu/nib-coffee-chat-sp26',
-            image: require('../img/prof/grace.jpg'),
-            sillyImage: require('../img/funny/grace.jpeg'),
-            isDM: false
-        },
-        {
-            name: 'Mehul Nair', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hey everyone! I'm Mehul; I'm a senior currently studying Materials Science and Nuclear Engineering. I'm very passionate about climate sustainability and the long term implications of the materials we use. Going into my fifth semester in NIB, I’ve had the opportunity to work on incredible projects with some of my best friends! Throughout my time in NIB, I’ve gotten the privilege to work on sustainable farming with Kiss The Ground, carbon capture with Climeworks and technology access with Goodwater Capital. Each of these projects has taught me so much and I have been delighted to see the tangible impact that we’ve made through them. In addition, NIB is such an amazing community and I love how much we show up and care for each other. NIB is full of people who are always there for you and I am lucky to have a club of some of my closest friends.",
-                "Outside of NIB, I work on superconductivity at Berkeley Lab and I joined TSMC as an Epitaxy Intern last summer summer. In addition, I like to go on late-night drives with friends, watch soccer and learn new things! If you want to chat more on anything here, feel free to stop by while I’m tabling or come to any of our info sessions!"],
-            linkedin: 'http://linkedin.com/in/mehnai/',
-            calendly: 'https://calendly.com/mehulnair/nib-coffee-chats',
-            image: require('../img/prof/Mehul.jpg'),
-            sillyImage: require('../img/funny/mehul.png'),
-            isDM: false
-        },
-        {
-            name: 'Hunter Valencia', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hello, I hope you are doing well! My name is Hunter; I'm a Senior studying Political Science. I joined Net Impact my Freshman Fall, and it's been an incredible three years of working on projects and discovering my passions in the career field. I love how Net Impact integrated my major in Poli Sci with fields in Business, Law, and Tech. This semester I've had the wonderful opportunity to serve as Project Manager, and I cannot wait to see how this club develops this Semester.",
-                "NIB has created so many core memories that have shaped who I am. If you have any questions, or want to talk about Cal's Football Team, I'm all ears!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/hunter-valencia-42216424b',
-            calendly: 'https://calendly.com/sunwardloki/nib-coffee-chat-1',
-            image: require('../img/prof/hunter.jpg'),
-            sillyImage: require('../img/funny/hunter.png'),
-            isDM: false
-        },
-        {
-            name: 'William Little',
-            title: 'Senior Advisor',
-            bio: [
-                "Hey! I'm Will, a senior from Sacramento, California, studying aerospace engineering. I joined Net Impact in Spring 2024 and am currently a Senior Advisor this semester. Last semester, I worked with Diageo, where I helped create a machine-learning algorithm to optimize water usage in their beverage production process.",
-                "I'm interested in improving diversity in STEM, technology, engineering, and program and product management. In the past, I've worked at NASA as a Systems Engineering intern for over a year. I love to play basketball, cook, and binge-watch superhero movies in my free time. Feel free to reach out to chat about anything!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/williamalexlittle/',
-            calendly: "https://calendly.com/william-little-berkeley/nib-coffee-chats",
-            image: require('../img/prof/will.png'),
-            sillyImage: require('../img/funny/will.png'),
-            isDM: false
-        },
-        {
-            name: 'Charlie Gu', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hey I'm Charlie! I'm a senior and study EECS + Business. I was lucky enough to join NIB in my first semester of college and without it, I'd be lost. The people I've met + the work I've done for incredible clients like Amazon, CLIF Bar, and Diageo have been absolutely extraordinary. I know everyone says that about their clubs but trust me I mean it. Apply - you won't regret it.",
-                "Some other things about me: I'm learning how to DJ, I just got back from studying abroad in Madrid so you know I'm going to be absolutely insufferable about my experience, and I'm the reigning IM Pickleball champion."
-            ],
-            linkedin: 'https://www.linkedin.com/in/charleszgu/',
-            calendly: 'https://calendly.com/chargu/30-minute-meeting',
-            image: require('../img/prof/charlie.png'),
-            sillyImage: require('../img/funny/charlie.png'),
-            isDM: false
-        },
-        {
-            name: 'Malik Mbugua', 
-            title: 'Senior Advisor',
-            bio: [
-                "What’s the word everyone my name is Malik Mbugua, and I’m a fourth-year majoring in Political Economy with a concentration in Technology/Data Science. I'm from South Central Los Angeles, and I’m currently a Senior Advisor this semester. After joining NIB in my sophomore fall semester, I’ve been able to work on amazing projects such as TurtleTree in aiding in the launch of new biomedical innovations and Diageo to improve their production water use.",
-                "Aside from this, I have a love for social impact, specifically dealing with homelessness and youth outreach, which I do with non-profits I’ve helped as a co-founder in Berkley and LA. If you want to talk about social impact, anime, basketball, music, or anything else random, feel free to tap in!"
-            ],
-            linkedin: 'https://www.linkedin.com/in/malik-mbugua?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app',
-            calendly: "https://calendly.com/mmbugua-1/nib-coffee-chat",
-            image: require('../img/prof/malik.jpg'),
-            sillyImage: require('../img/funny/malik.jpg'),
-            isDM: false
-        },
-        {
-            name: 'Mariah Branscomb', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hi everyone! I'm Mariah and my social impact area is DEI initiatives and disability awareness/inclusion. I am going to be a Senior Advisor this semester as well as the Executive of Professional Development and Alumni Affairs for the Haas Undergraduate Black Business Association.", 
-                "In my free time I love eating, taking naps, and baking sourdough bread. Feel free to reach out! "
-            ],
-            linkedin: 'https://www.linkedin.com/in/mariah-branscomb',
-            image: require('../img/prof/mariah.jpg'),
-            sillyImage: require('../img/funny/mariah.jpg'),
-            isDM: true
         },
         {
             name: 'Frances Rich', 
@@ -682,20 +473,263 @@ let memberInfo = {
             sillyImage: require('../img/funny/frances.png'),
             isDM: true
         },
+
+        // ---- Graduated: kept for reference, not rendered ----
+        /*
         {
-            name: 'Melanie Davidson',
-            title: 'Senior Advisor',
+            name: 'Muhammed Ibrahim Bakr', 
+            title: 'President',
             bio: [
-                "Hi! My name is Mel, and I am a current sophomore, majoring in Cognitive Science and intending to pursue Data Science as well! I joined NIB in my freshman spring and have loved working alongside and learning from the many amazing people in this club, particularly through my project with SFO Airport. However, the NIBfam community extends further than my project, surrounding me with such interesting, dedicated, and kind people that I could not be more grateful for!", 
-                "Besides school, I am on the Club Volleyball team here at Cal, and I enjoy crocheting, reading books about niche scientific topics, trying out new restaurants and cafes with my friends, and running. I am always open to new adventures or anything with good conversation! I can’t wait to meet you!!",
-                "Melanie is studying abroad this semester."
+                "Hey I'm Muhammed, a senior born and raised in Botswana, majoring in Economics, and minoring in Global Poverty Practice and Data Science. I joined NIB in Fall '23 and it's been one of my best decisions in college. Not only have I gained invaluable experience at companies I dream of working for, on projects I feel are truly meaningful, I've also made some of my closest friends since coming to America.",
+                "I'm super interested in extreme poverty alleviation, and NIB has helped me channel that passion through our work with the World Bank on WASH in the Pacific, and the Global Alliance for Improved Nutrition (GAIN) on food security in East Africa. I've also worked on econometric analysis on California wildfire resilience projects for the EDF and sales strategy for Climeworks, a leader in the direct air capture premium carbon offset credit market.",
+                "Talk to me about anything football/soccer related (I'm a Liverpool fan), the NBA (Golden State), Effective Altruism, or music (Afro beats, Dominic Fike, J. Cole, JID, Mac Miller)."
             ],
-            linkedin: 'https://linkedin.com/in/melanie-davidson-711919325',
-            calendly: 'https://calendly.com/melaniebdavidson-berkeley/30min',
-            image: require('../img/prof/Mel.jpg'),
-            sillyImage: require('../img/funny/mel.png'),
+            linkedin: 'https://www.linkedin.com/in/muhammed-bakr/',
+            calendly: 'https://calendly.com/muhammed-bakr/nib-coffee-chats',
+            image: require('../img/prof/Muha.jpg'),
+            sillyImage: require('../img/funny/muha.png'),
             isDM: true
         },
+        */
+        /*
+        {
+            name: 'Ashni Sheth', 
+            title: 'VP Finance & Operations',
+            bio: [
+                "Hi hi! I'm Ashni - I'm a fourth year studying EECS and joined NIB in my sophomore spring. Since then, I've had the immense privilege of calling this community home, building the deepest friendships and support system I could have asked for. During my time at NIB, I've worked on market expansion for The Hunger Project and marketing strategy for the United Nations Foundation.",
+                "Outside of NIB, I have trained in dance for over 15 years and am part of a team at Berkeley (shoutout Zahanat)! I'm also a member of Alpha Delta Pi (ADPi) and deeply involved in venture capital and entrepreneurship on- and off-campus. I am thrilled to have the opportunity to meet you!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/ashni-sheth-4629041b3/',
+            calendly: 'https://calendly.com/ashni_sheth/nib-coffee-chats',
+          image: require('../img/prof/Ashni.jpg'),
+            sillyImage: require('../img/funny/ashni.png'),
+            isDM: true
+        },
+        */
+        /*
+        {
+            name: 'Wenhan Xi', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hi there! I’m Han, and I’m a Senior studying econ and data science. I joined NIB freshman fall and it's here that I've found a home. So far, I've had the privilege to work on amazing projects from developing social enterprise partnership strategies for the aerospace industry to digital readiness with farmers and even on a corporate partnership strategy for an environmental advocacy group. Last year, I led my own project supporting the World Bank's efforts in promoting Water and Sanitation investment, before serving as NIB's VP Consulting and President.",
+                "Outside of NIB, I love judo, building houses and cooking up a storm in the kitchen (cleaning up after though is something I'm still working on...) I’m super excited to meet you through recruitment this Spring!"
+               ],
+            linkedin: 'https://www.linkedin.com/in/wenhanxi/',
+            calendly: 'https://calendar.app.google/d2n8TsidFUFbzFD29',
+            image: require('../img/prof/Han.jpg'),
+            sillyImage: require('../img/funny/han.png'),
+            isDM: false
+         },
+        */
+        /*
+        {
+            name: 'Breanna Pearlman', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hi! I’m Breanna, and I’m a senior studying Global Studies and Political Science with a minor in Human Rights. I joined NIB my freshman spring, and it has been the best decision I’ve made! In my short time in NIB so far I have already made such amazing memories and met some of my closest friends. In the past, I’ve worked on social impact initiative ideation for a leading energy bar company and food safety testing implementation for the Global Alliance for Improved Nutrition. Last semester, I co-led a project in partnership with the Hunger Project that focused on expanding the organization's youth programs.", 
+                "Outside of consulting, I am interested in human rights, environmental justice, African development, and Timothée Chalamet. I am also involved in on-campus research. In my free time, I love shopping, hiking, and traveling. I just got back from a semester abroad in Paris in the spring. Feel free to reach out and chat, and I look forward to meeting you! Feel free to reach out and chat, and I look forward to meeting you!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/breanna-pearlman-637119251/',
+            calendly: 'https://calendly.com/breannapearlman/nib-spring-26-coffee-chats?month=2026-01',
+            image: require('../img/prof/bre.jpg'),
+            sillyImage: require('../img/funny/breanna.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Charlie Gu', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hey I'm Charlie! I'm a senior and study EECS + Business. I was lucky enough to join NIB in my first semester of college and without it, I'd be lost. The people I've met + the work I've done for incredible clients like Amazon, CLIF Bar, and Diageo have been absolutely extraordinary. I know everyone says that about their clubs but trust me I mean it. Apply - you won't regret it.",
+                "Some other things about me: I'm learning how to DJ, I just got back from studying abroad in Madrid so you know I'm going to be absolutely insufferable about my experience, and I'm the reigning IM Pickleball champion."
+            ],
+            linkedin: 'https://www.linkedin.com/in/charleszgu/',
+            calendly: 'https://calendly.com/chargu/30-minute-meeting',
+            image: require('../img/prof/charlie.png'),
+            sillyImage: require('../img/funny/charlie.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'William Little',
+            title: 'Senior Advisor',
+            bio: [
+                "Hey! I'm Will, a senior from Sacramento, California, studying aerospace engineering. I joined Net Impact in Spring 2024 and am currently a Senior Advisor this semester. Last semester, I worked with Diageo, where I helped create a machine-learning algorithm to optimize water usage in their beverage production process.",
+                "I'm interested in improving diversity in STEM, technology, engineering, and program and product management. In the past, I've worked at NASA as a Systems Engineering intern for over a year. I love to play basketball, cook, and binge-watch superhero movies in my free time. Feel free to reach out to chat about anything!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/williamalexlittle/',
+            calendly: "https://calendly.com/william-little-berkeley/nib-coffee-chats",
+            image: require('../img/prof/will.png'),
+            sillyImage: require('../img/funny/will.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Malik Mbugua', 
+            title: 'Senior Advisor',
+            bio: [
+                "What’s the word everyone my name is Malik Mbugua, and I’m a fourth-year majoring in Political Economy with a concentration in Technology/Data Science. I'm from South Central Los Angeles, and I’m currently a Senior Advisor this semester. After joining NIB in my sophomore fall semester, I’ve been able to work on amazing projects such as TurtleTree in aiding in the launch of new biomedical innovations and Diageo to improve their production water use.",
+                "Aside from this, I have a love for social impact, specifically dealing with homelessness and youth outreach, which I do with non-profits I’ve helped as a co-founder in Berkley and LA. If you want to talk about social impact, anime, basketball, music, or anything else random, feel free to tap in!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/malik-mbugua?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app',
+            calendly: "https://calendly.com/mmbugua-1/nib-coffee-chat",
+            image: require('../img/prof/malik.jpg'),
+            sillyImage: require('../img/funny/malik.jpg'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Mariah Branscomb', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hi everyone! I'm Mariah and my social impact area is DEI initiatives and disability awareness/inclusion. I am going to be a Senior Advisor this semester as well as the Executive of Professional Development and Alumni Affairs for the Haas Undergraduate Black Business Association.", 
+                "In my free time I love eating, taking naps, and baking sourdough bread. Feel free to reach out! "
+            ],
+            linkedin: 'https://www.linkedin.com/in/mariah-branscomb',
+            image: require('../img/prof/mariah.jpg'),
+            sillyImage: require('../img/funny/mariah.jpg'),
+            isDM: true
+        },
+        */
+        /*
+        {
+            name: 'Madelyn Christensen',
+            title: 'Senior Advisor',
+            bio: [
+                "Hello! I'm Madelyn, a senior studying Cognitive Science & Data Science. Since joining NIB in 2022, I've had the opportunity to work on a wide range of exciting projects with some of the largest non-profits in the world on the global healthcare crisis. I also had the opportunity to lead my own team on a project about AI usage in universities, partnering with a leading AI detection company.",
+                "Outside of NIB, you can find me reading on the glade, dancing with some of Cal's dance teams, exploring coffee shops, or debating. NIB has given me a wide range of experiences and opportunities that I never could've imagined. But more than any of that, it's given me a truly amazing community here on Berkeley's campus to connect with. So much love for NIBFAM!!",
+            ],
+            linkedin: 'https://www.linkedin.com/in/madelynchristensen/',
+            calendly: 'https://calendly.com/madelync-1/nib-fall-2024-coffee-chats',
+            image: require('../img/prof/Madelyn Christensen.jpg'),
+            sillyImage: require('../img/funny/madelyn.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Srijani Sarkar', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hi! Im Srijani, a senior majoring in MEB & Cognitive Science. Joining NIB was an amazing decision, and the people I met quickly became family. I've had the privilege of working on two projects, TurtleTree and Diageo, and leading one with SFO.",
+                "Outside of NIB, I am a member of PhiDE, a pre medical fraternity, and plan on going into Life Sciences consulting before attending medical school. Talk to me about anything sports related (I play IM basketball & club lacrosse at Berkeley, and work for the athletic department), going abroad/traveling (I studied in Madrid last fall), or about concerts and music (some favs are Daniel Caesar, Mac Demarco, Gunna, SZA, Joey Bada$$, Chris Stapleton)"
+            ],
+            calendly: 'https://calendly.com/srijani-sarkar/nib-coffee-chats',
+            linkedin: 'https://www.linkedin.com/in/srijani-sarkar-035016200/',
+            image: require('../img/prof/srijani.jpg'),
+            sillyImage: require('../img/funny/srijani.jpeg'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Nikith Vangala',
+            title: 'Senior Advisor',
+            bio: [
+                "Hi! It's great to meet you :) My name is Nikith and I'm a senior studying EECS and Business. I'm going to be a senior advisor this semester, and have served as VP Finance & Operations and President over the past few semesters.",   
+                "NIB has been my home away from home since my first semester at school. I've met my closest friends and roommates through this club and I couldn't be more thankful for all the opportunities it's provided me. I've worked on four projects so far: roadmapping health product procurement in Africa for one of the largest nonprofit orgs in the world, growth strategy for a sustainable clothing retailer, a go-to-market strategy for a new biotechnology startup with a sustainable alternative to a milk derivative, and building a recognition algorithm for a stealth-stage startup.",
+                "I am also a member of UCB Zahanat, a Bollywood fusion dance team here on campus."
+            ],
+            linkedin: 'https://linkedin.com/in/nikith-vangala',
+            calendly: 'https://calendly.com/nikith-vangala/nib-coffee-chats',
+            image: require('../img/prof/Nikith.jpg'),
+            sillyImage: require('../img/funny/nikith.jpg'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Sashank Gadisetti', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hello! I'm Sashank and I am currently a senior studying computer science. I joined NIB my junior fall and it's been an amazing experience so far. I've had the opportunity to work with a sustainable fashion company looking to expand into the EU so far. I personally am passionate about personalized, accessible education everywhere. I've had an amazing experience in NIB so far and I'm super excited for what the semester has in store. Super excited to meet everyone!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/sashank-gadisetti',
+            calendly: 'https://calendly.com/sgadisetti-berkeley/coffee-chats',
+            image: require('../img/prof/Sashank.jpg'),
+            sillyImage: require('../img/funny/sashank.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Hunter Valencia', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hello, I hope you are doing well! My name is Hunter; I'm a Senior studying Political Science. I joined Net Impact my Freshman Fall, and it's been an incredible three years of working on projects and discovering my passions in the career field. I love how Net Impact integrated my major in Poli Sci with fields in Business, Law, and Tech. This semester I've had the wonderful opportunity to serve as Project Manager, and I cannot wait to see how this club develops this Semester.",
+                "NIB has created so many core memories that have shaped who I am. If you have any questions, or want to talk about Cal's Football Team, I'm all ears!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/hunter-valencia-42216424b',
+            calendly: 'https://calendly.com/sunwardloki/nib-coffee-chat-1',
+            image: require('../img/prof/hunter.jpg'),
+            sillyImage: require('../img/funny/hunter.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Mehul Nair', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hey everyone! I'm Mehul; I'm a senior currently studying Materials Science and Nuclear Engineering. I'm very passionate about climate sustainability and the long term implications of the materials we use. Going into my fifth semester in NIB, I’ve had the opportunity to work on incredible projects with some of my best friends! Throughout my time in NIB, I’ve gotten the privilege to work on sustainable farming with Kiss The Ground, carbon capture with Climeworks and technology access with Goodwater Capital. Each of these projects has taught me so much and I have been delighted to see the tangible impact that we’ve made through them. In addition, NIB is such an amazing community and I love how much we show up and care for each other. NIB is full of people who are always there for you and I am lucky to have a club of some of my closest friends.",
+                "Outside of NIB, I work on superconductivity at Berkeley Lab and I joined TSMC as an Epitaxy Intern last summer summer. In addition, I like to go on late-night drives with friends, watch soccer and learn new things! If you want to chat more on anything here, feel free to stop by while I’m tabling or come to any of our info sessions!"],
+            linkedin: 'http://linkedin.com/in/mehnai/',
+            calendly: 'https://calendly.com/mehulnair/nib-coffee-chats',
+            image: require('../img/prof/Mehul.jpg'),
+            sillyImage: require('../img/funny/mehul.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Brian Poh',
+            title: 'Senior Advisor',
+            bio: [
+                "Hey I'm Brian and I'm currently a junior studying Analytics. I joined NIB my sophomore spring semester and it has really made my experience at Cal more fulfilling and memorable. My prior project experience working with the Environmental Defense Fund allowed me to help develop data-driven wildfire resilience strategies based on grant trend analysis.",
+                "I'm interested in exploring current regulated hospitality practices and standards to advance eco-tourism and sustainable development. In the past, I have also volunteered in Cambodia and Southern Taiwan, specifically focusing on supporting local initiatives that strive to improve the quality of education.", 
+                "In my free time I like to play sports, watch Netflix, cook, travel, and spend quality time with my friends and family. Don't hesitate to reach out!]"
+            ],
+            linkedin: 'https://www.linkedin.com/in/brian-poh-b8686637b/',
+            calendly: 'https://calendly.com/brianpoh/brian-nib-spring-26-coffee-chats',
+            image: require('../img/prof/Brian.jpg'),
+            sillyImage: require('../img/funny/brian.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Elan Trager', 
+            title: 'Senior Advisor',
+            bio: [
+                    "Hello! I'm Elan, a senior studying Environmental Econ and Data Science. As I enter my sixth semester in NIB, I have nothing but love for everyone in this org. Throughout my time here I’ve gotten to work with recognizable companies on relevant sustainability efforts, while increasingly becoming closer to this amazing community. I cannot wait to welcome in our next round of Niblets!",
+                    "In my free time I can be found at the climbing gym (shoutout Mosaic), RSF, being a tad too competitive on our NIB IM sports teams, or laying on the glade in the sun with some still woozy playing."],
+            linkedin: 'https://www.linkedin.com/in/elan-trager-a9a2311a9/',
+            calendly: 'https://calendly.com/elantrager/nib-coffee-chatsky',
+            image: require('../img/prof/Elan.jpg'),
+            sillyImage: require('../img/funny/elan.png'),
+            isDM: false
+        },
+        */
+        /*
+        {
+            name: 'Grace Hu', 
+            title: 'Senior Advisor',
+            bio: [
+                "Hi, I’m Grace! I’m a fourth-year from Shanghai majoring in Political Economy and Economics, with minors in Public Policy and Data Science. I joined NIB in Fall ’23, and it’s become a quintessential part of my college experience.",
+                "In NIB, I’ve served as VP of Finance and Operations, led a project with one of the world’s largest humanitarian NGOs, and worked with both a multinational corporation to enhance its sustainability program and a direct-air-capture climate tech company on growth strategy.",
+                "As a first-generation college student, I’m deeply passionate about poverty alleviation and global development. Outside of NIB, I’m heavily involved in social science research, love spontaneous midnight drives, savor a great meal, and enjoy solo traveling. Excited to meet you all soon!"
+            ],
+            linkedin: 'https://www.linkedin.com/in/gracexyhu/',
+            calendly: 'https://calendly.com/grace_hu/nib-coffee-chat-sp26',
+            image: require('../img/prof/grace.jpg'),
+            sillyImage: require('../img/funny/grace.jpeg'),
+            isDM: false
+        },
+        */
     ]
 } 
 

--- a/src/members/data/memberInfo.js
+++ b/src/members/data/memberInfo.js
@@ -24,7 +24,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/aswinsurya/nib-coffee-chats',
             image: require('../img/prof/Aswin.jpg'),
             sillyImage: require('../img/funny/aswin.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Lauren Lemire',
@@ -63,7 +63,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/maitree-meher-berkeley/nib-calendly',
             image: require('../img/prof/Maitree.jpg'),
             sillyImage: require('../img/funny/maitree.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Eshaan Shaik', 
@@ -79,6 +79,8 @@ let memberInfo = {
             sillyImage: require('../img/funny/eshaan.png'),
             isDM: true
         },
+    ],
+    pmList: [
         {
             name: 'Harper Young',
             title: 'Project Manager',
@@ -90,7 +92,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/harperyoung-berkeley/30min',
             image: require('../img/prof/harper.png'),
             sillyImage: require('../img/funny/harper.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Elias Goss',
@@ -102,7 +104,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/eliasgoss2005-berkeley',
             image: require('../img/prof/Elias.jpg'),
             sillyImage: require('../img/funny/elias.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Luis Suarez',
@@ -114,7 +116,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/luis_suarez-berkeley/30min',
             image: require('../img/prof/Luis.jpg'),
             sillyImage: require('../img/funny/luis.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Jules De Boni',
@@ -127,7 +129,7 @@ let memberInfo = {
             calendly: 'https://calendly.com/julesdeboni-berkeley/30min',
             image: require('../img/prof/jules.jpg'),
             sillyImage: require('../img/funny/jules.png'),
-            isDM: false
+            isDM: true
         },
         {
             name: 'Melanie Davidson',
@@ -157,11 +159,8 @@ let memberInfo = {
             calendly: 'https://calendly.com/kabir-dua-berkeley/nib-coffee-chat-sp-26',
             image: require('../img/prof/kabir.jpg'),
             sillyImage: require('../img/funny/kabir.png'),
-            isDM: false
+            isDM: true
         },
-    ],
-    pmList: [
-        /* add when we go back to 5 pms lol */
     ],
 
     memberList: [
@@ -431,20 +430,6 @@ let memberInfo = {
             calendly: 'https://calendly.com/tpmandy24/nib-coffee-chat',
             image: require('../img/prof/Mandy.jpg'),
             sillyImage: require('../img/funny/mandy.png'),
-            isDM: false
-        },
-        {
-            name: 'Raymond Yuan', 
-            title: 'Senior Advisor',
-            bio: [
-                "Hello! My name is Raymond and I am a Junior majoring in Philosophy and Computer Science. As you can tell from my majors, I love to try new things and see different perspectives of the world. I am very thankful for NIB to have given me the opportunity to work with many diverse and talented individuals.",
-                "For me social impact comes in the way of understanding. Because it is so much easier to change the mind of a friend than an enemy. To this end, I find it very hopeful that NIB is trying to make social impact happen in the corporate world, where people usually imagine black hearts and cold hands.",
-                "In my free time I think about little things and how life came to be. Reach out if you're prepared for the conversation to be derailed to somewhere strange and curious!"
-            ],
-            linkedin: 'www.linkedin.com/in/raymond-yuan-yayayayay',
-            calendly: 'https://calendly.com/raymondyuan9/30min?month=2026-01',
-            image: require('../img/prof/raymond.png'),
-            sillyImage: require('../img/funny/raymond.png'),
             isDM: false
         },
         {

--- a/src/members/member.scss
+++ b/src/members/member.scss
@@ -74,10 +74,17 @@
         margin: 1%;
     }
     // Leadership and PMs are groups of six: three per row gives two even rows
-    // instead of five plus an orphan. 31.333% + 1% margins fills the same 100%
-    // as the members grid (5 x 20%), so all three sections share edges.
+    // instead of five plus an orphan. Narrowing the group to 60% and scaling
+    // within it keeps photos and gaps identical to the members grid
+    // (30% x 60% = 18% wide, 1.65% x 60% = 1% margin), leaving the remaining
+    // 40% as even whitespace either side.
+    .leadershipGrid {
+        max-width: 60%;
+        margin: 0 auto;
+    }
     .leadershipGrid .memberProfile {
-        width: 31.333%;
+        width: 30%;
+        margin: 1.65%;
     }
 }
 

--- a/src/members/member.scss
+++ b/src/members/member.scss
@@ -50,6 +50,12 @@
     }
 }
 
+// Leadership and PM rows are centered so a partial row sits mid-container
+// rather than stranded on the left.
+.leadershipGrid {
+    text-align: center;
+}
+
 .clickable {
     cursor: pointer;
 }
@@ -67,10 +73,12 @@
         width: 18%;
         margin: 1%;
     }
-    // .memberProfile.execProfile {
-    //     height: 14.5%;
-    //     width: 14.5%;
-    // }
+    // Leadership and PMs are groups of six: three per row gives two even rows
+    // instead of five plus an orphan. 31.333% + 1% margins fills the same 100%
+    // as the members grid (5 x 20%), so all three sections share edges.
+    .leadershipGrid .memberProfile {
+        width: 31.333%;
+    }
 }
 
 @media (max-width: 800px) {

--- a/src/members/members.js
+++ b/src/members/members.js
@@ -226,8 +226,9 @@ const Members = () => {
                 <section className="container">
                     <h2>Leadership Team</h2>
                     <div>{execList}</div>
-                    <h2>Members</h2>
+                    <h2>Project Managers</h2>
                     <div>{pmList}</div>
+                    <h2>Members</h2>
                     <div>{memberList}</div>
                 </section>
             </section>

--- a/src/members/members.js
+++ b/src/members/members.js
@@ -225,9 +225,9 @@ const Members = () => {
                 </section>
                 <section className="container">
                     <h2>Leadership Team</h2>
-                    <div>{execList}</div>
+                    <div className="leadershipGrid">{execList}</div>
                     <h2>Project Managers</h2>
-                    <div>{pmList}</div>
+                    <div className="leadershipGrid">{pmList}</div>
                     <h2>Members</h2>
                     <div>{memberList}</div>
                 </section>


### PR DESCRIPTION
Updates the members page roster and the apply page timeline for the Fall 2026 cycle.

## Members page

**Leadership**
| | |
|---|---|
| Ice Kulruchakorn | President |
| Aswin Surya | VP Finance & Operations |
| Lauren Lemire | VP External |
| Renaissance Zhang | VP Internal |
| Maitree Meher | VP Associate Development |
| Eshaan Shaik | VP Consulting |

**Project Managers** — Harper Young, Elias Goss, Luis Suarez, Jules De Boni, Melanie Davidson, Kabir Dua

**Senior Associates** — Vish Goel, Zoey Bahng, Vedatman Duhoon, Vit Do

**Returning Associates** — Dia Hemanth, Sid Avula, Dylan Gunadi, Lilliana Calvert, Ayla Margate, Erica Chen, Anthony Sapp Guadarrama, Amy Tanaka

**Senior Advisors** — everyone else remaining.

**Graduated** — commented out rather than deleted, so bios and photos stay in the file: Muha, Ashni, Wenhan, Breanna, Charlie, William, Malik, Mariah, Madelyn, Srijani, Nikith, Sashank, Hunter, Mehul, Brian, Elan, Grace.

Every member's bio, LinkedIn, Calendly and images carry over verbatim — only titles and ordering changed. 52 members in, 52 accounted for (12 leadership + 23 listed + 17 commented out).

## Apply page

Hero copy replaces the closed-Spring-2026 notice with *"Stay tuned for information about our upcoming Fall 2026 recruitment cycle!"*

| Stage | Dates |
|---|---|
| Tabling | Wed 8/26 – Fri 9/4 |
| Info sessions | Tue 9/1 – Thu 9/3 |
| Applications & interviews | Fri 9/4 – Wed 9/9 |
| **Applications due** | **Fri 9/4, 1 PM PST** |

Detailed timeline: Info Session #1 Tue 9/1, Info Session #2 + Case Workshop Wed 9/2, Case Coaching Thu 9/3, apps due Fri 9/4, first rounds Sat 9/5, Meet NIB Sun 9/6, coffee chats Mon 9/7, second rounds Tue 9/8, welcome Wed 9/9. All weekdays checked against the 2026 calendar.

## Also fixed

8 headshots were referenced with the wrong capitalization (`prof/muha.jpg` vs the tracked `Muha.jpg`; same for Ashni, Diane, Eshaan, Elias, Anika, Grayson, Elan). These resolve on macOS because the filesystem is case-insensitive, but would fail a build on Linux CI. Fixed in both the active and commented-out entries.

## Still needed before this goes live

- **The interest form link is unchanged** — still points at the old Airtable form. Needs swapping once the new one exists.
- Info session locations still say VLSB 2040, carried over from last cycle. Confirm before merging.

## Verification

Built and rendered locally; roster and all timeline dates confirmed correct in the DOM.

## Note

Stacks cleanly with #49 (image loading fix) — no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)